### PR TITLE
Add support for the uscms and hcc repos in osg-promote.

### DIFF
--- a/osg-promote
+++ b/osg-promote
@@ -169,7 +169,7 @@ def get_tag(pattern, dver=None):
         tag = (# New-style tags
                get_first_tag('exact', '%s-%s-%s' % (split_pattern[0], dver, split_pattern[-1])) or # like hcc-el6-testing
                get_first_tag('exact', "%s-%s" % (pattern, dver)) or # like uscms-el6
-               get_first_tag('regex', "%s-(osg-)?-%s.*" % (re.escape(pattern), dver)) or # like osg-el6-release-3.1.3
+               get_first_tag('regex', "%s-%s-%s.*" % (re.escape(split_pattern[0]), dver, re.escape(split_pattern[-1])) or # like osg-el6-release-3.1.3
                # old-style tags
                get_first_tag('exact', "%s-%s" % (dver, pattern)) or # like el5-osg
                get_first_tag('exact', "%s-osg-%s" % (dver, pattern)) or # like el5-osg-upcoming


### PR DESCRIPTION
This adds a new route for the hcc repos.  If uscms wants to have a testing / release split, they'll also need the changes to the get_tag function.

Note that this could support the OSG 3.1 / 3.2 split if we kept the name of the "primary" release tags to "osg-release" and just added new routes for OSG 3.1.  Otherwise, we'd need an osg-build release per major version (which, considering, is not that horrible).
