### PR TITLE
Add (-3) --diff3 option for a three-way diff.

### DIFF
--- a/osg-import-srpm
+++ b/osg-import-srpm
@@ -1,35 +1,44 @@
 #!/usr/bin/env python
 
-# TODO This is a fairly rough script that I haven't gotten around to cleaning up.
 import glob
-from optparse import OptionParser
 import logging
-from logging import debug, critical, warning
 import re
-from os import chdir, getcwd, unlink
-from os.path import (abspath, basename, exists, isdir)
-from os.path import join as opj
-from shutil import move
+from optparse import OptionParser
+import os
+import shutil
 import sys
-from traceback import format_exc
+import traceback
 
-from osgbuild.utils import (checked_call, safe_makedirs,
-                                 unchecked_call, unslurp, slurp) 
+from osgbuild import utils
 
 # Constants:
 VDT_WWW = "/p/vdt/public/html"
-DEFAULT_UPSTREAM_ROOT = opj(VDT_WWW, "upstream")
+DEFAULT_UPSTREAM_ROOT = os.path.join(VDT_WWW, "upstream")
 DEFAULT_LOG_LEVEL = logging.INFO
+
+
+EXTRA_ACTION_DIFF_SPEC = 'diff_spec'
+EXTRA_ACTION_EXTRACT_SPEC = 'extract_spec'
+EXTRA_ACTION_DIFF3_SPEC = 'diff3_spec'
+
+PROVIDER_PATTERNS = [
+    (r'emisoft\.web\.cern\.ch'         , 'emi')    ,
+    (r'fedoraproject\.org/pub/epel/'   , 'epel')   ,
+    (r'fedoraproject\.org/pub/fedora/' , 'fedora') ,
+    (r'globus\.org'                    , 'globus') ]
+
+
+
 
 class Error(Exception):
     """Base class for expected exceptions. Caught in main(); may include a
     traceback but will only print it if debugging is enabled.
-    
+
     """
     def __init__(self, msg, tb=None):
         self.msg = msg
         if tb is None:
-            self.traceback = format_exc()
+            self.traceback = traceback.format_exc()
 
     def __repr__(self):
         return repr((self.msg, self.traceback))
@@ -43,19 +52,21 @@ class UsageError(Error):
         Error.__init__(self, "Usage error: " + msg + "\n")
 
 
+
+
 def download_srpm(url, output=None):
     """Download an srpm from url. Return the filename."""
     # TODO: This should probably use urllib2
     if output is None:
-        output = basename(url)
+        output = os.path.basename(url)
     cmd = ["wget", "-q", url, "-O", output]
-    checked_call(cmd)
+    utils.checked_call(cmd)
     return output
 
 
 def srpm_nvr(srpm):
     """Extract the NVR (Name, Version, Release) from the name of an srpm."""
-    base_srpm = basename(srpm)
+    base_srpm = os.path.basename(srpm)
     match = re.match(r"""(.+)-(.+)-(.+)\.src\.rpm$""",
                      base_srpm)
     if match:
@@ -66,7 +77,7 @@ def srpm_nvr(srpm):
                     base_srpm)
 
 
-def make_svn_tree(srpm, url, extract_spec=False, diff_spec=False, provider=None):
+def make_svn_tree(srpm, url, extra_action=None, provider=None):
     """Create an svn tree for the srpm and populate it as follows:
     $name/osg/*.spec        - the spec file as extracted from the srpm
                               (if extract_spec is True)
@@ -75,106 +86,326 @@ def make_svn_tree(srpm, url, extract_spec=False, diff_spec=False, provider=None)
 
     """
     name, version = srpm_nvr(srpm)[0:2]
-    upstream_dir = opj(name, "upstream")
-    abs_srpm = abspath(srpm)
-    base_srpm = basename(srpm)
-    
-    if not exists(name):
-        checked_call(["svn", "mkdir", name])
-    if not exists(upstream_dir):
-        checked_call(["svn", "mkdir", upstream_dir])
+    abs_srpm = os.path.abspath(srpm)
 
+    # HACK - if we're already in the package directory
+    if os.path.basename(os.getcwd()) == name:
+        os.chdir("..")
+
+    if not os.path.exists(name):
+        utils.checked_call(["svn", "mkdir", name])
+
+    osg_dir = os.path.join(name, "osg")
+    if extra_action == EXTRA_ACTION_DIFF_SPEC:
+        diff_spec(abs_srpm, osg_dir, want_diff3=False)
+    elif extra_action == EXTRA_ACTION_EXTRACT_SPEC:
+        extract_spec(abs_srpm, osg_dir)
+    elif extra_action == EXTRA_ACTION_DIFF3_SPEC:
+        if os.path.isdir(osg_dir):
+            extract_orig_spec(osg_dir)
+        diff_spec(abs_srpm, osg_dir, want_diff3=True)
+
+    upstream_dir = os.path.join(name, "upstream")
+
+    if not os.path.exists(upstream_dir):
+        utils.checked_call(["svn", "mkdir", upstream_dir])
+
+    cached_filename = os.path.join(name, version, srpm)
+
+    make_source_file(url, cached_filename, upstream_dir, provider)
+
+    if len(glob.glob(os.path.join(upstream_dir, "*.source"))) > 1:
+        logging.info("More than one .source file found in upstream dir.")
+        logging.info("Examine them to make sure there aren't duplicates.")
+
+
+def make_source_file(url, cached_filename, upstream_dir, provider=None):
+    """Create an upstream/*.source file with the appropriate name based
+    on either `provider` or `url` if the former is not given.  Also add
+    the new file to SVN.
+    """
     if provider is None:
-        if re.search(r'emisoft\.web\.cern\.ch', url):
-            provider_name = 'emi'
-        elif re.search(r'fedoraproject\.org', url):
-            provider_name = 'epel'
+        for provpat, provname in PROVIDER_PATTERNS:
+            if re.search(provpat, url):
+                provider = provname
+                break
         else:
-            provider_name = 'developer'
+            provider = 'developer'
+
+    source_filename = os.path.join(upstream_dir, provider+".srpm.source")
+
+    source_contents = """\
+%(cached_filename)s
+# Downloaded from '%(url)s'
+""" % locals()
+
+    if os.path.exists(source_filename):
+        logging.info("Source file exists. Saving as %s.old", source_filename)
+        shutil.move(source_filename, source_filename + ".old")
+        utils.unslurp(source_filename, source_contents)
     else:
-        provider_name = provider
+        utils.unslurp(source_filename, source_contents)
+        svn_safe_add(source_filename)
 
-    source_filename = opj(upstream_dir, provider_name+".srpm.source")
 
-    source_contents = "%s\n# Downloaded from '%s'\n" % (opj(name, version, srpm), url)
+def is_untracked_path(path):
+    """Return True if the given path is untracked in SVN.
+    Note: ignored files return False.
+    """
+    output, ret = utils.sbacktick(["svn", "status", path])
 
-    if exists(source_filename):
-        print "Source file exists. Saving as %s.old" % source_filename
-        move(source_filename, source_filename + ".old")
-        unslurp(source_filename, source_contents)
-    else:
-        unslurp(source_filename, source_contents)
-        # TODO Check the path we're trying to add hasn't been added yet
-        checked_call(["svn", "add", source_filename])
-    if len(glob.glob(opj(upstream_dir, "*.source"))) > 1:
-        print "More than one .source file found in upstream dir."
-        print "Examine them to make sure there aren't duplicates."
+    return output.startswith('?')
 
-    osg_dir = opj(name, "osg")
-    if diff_spec:
-        # TODO: This needs touchups.
-        if not isdir(osg_dir):
-            print "No osg dir exists. Not diffing."
+
+def svn_safe_add(path):
+    """Add path to SVN if it's not already in there. Return True on success."""
+    if is_untracked_path(path):
+        ret = utils.unchecked_call(["svn", "add", path])
+        return ret == 0
+
+
+def get_spec_name_in_srpm(srpm):
+    """Return the name of the spec file present in an SRPM.  Assumes
+    there is exactly one spec file in the SRPM -- if there is more than
+    one spec file, returns the name of the first one ``cpio'' prints.
+    """
+    out, ret = utils.sbacktick("rpm2cpio %s | cpio -t '*.spec' 2> /dev/null" % re.escape(srpm), shell=True)
+    if ret != 0:
+        raise Error("Unable to get list of spec files from %s" % srpm)
+    try:
+        spec_name = filter(None, [x.strip() for x in out.split("\n")])[0]
+    except IndexError:
+        spec_name = None
+
+    if not spec_name:
+        raise Error("No spec file inside %s" % srpm)
+
+    return spec_name
+
+
+def extract_from_rpm(rpm, file_or_pattern=None):
+    """Extract a specific file or glob from an rpm."""
+    command = "rpm2cpio " + re.escape(rpm) + " | cpio -ivd"
+    if file_or_pattern:
+        command += " " + re.escape(file_or_pattern)
+    return utils.checked_call(command, shell=True)
+
+
+def diff2(old_file, new_file, dest_file=None):
+    """Do a 2-way diff, between `old_file` and `new_file`, where the
+    differences are shown with markers like what SVN makes for a file
+    with merge conflicts, e.g.:
+
+    '''
+    <<<<<<< old_file
+    old stuff
+    =======
+    new stuff
+    >>>>>>> new_file
+    '''
+
+    Write the result to `dest_file` if it is specified.
+    Return the text of the diff on success, None on failure.
+    """
+
+    diff, ret = utils.sbacktick(["diff", """\
+--changed-group-format=<<<<<<< %(old_file)s
+%%<=======
+%%>>>>>>>> %(new_file)s
+""" % locals(), old_file, new_file])
+    if not (ret == 0 or ret == 1):
+        logging.warning("Error diffing %s %s: diff returned %d",
+                        old_file, new_file, ret)
+        return
+
+    if dest_file:
+        utils.unslurp(dest_file, diff)
+        logging.info("Difference between %s and %s written to %s",
+                     old_file, new_file, dest_file)
+
+    return diff
+
+
+def diff3(old_file, orig_file, new_file, dest_file=None):
+    """Do a 3-way diff between `old_file`, `orig_file`, and `new_file`,
+    where the differences are shown with markers like what SVN makes
+    for a file with merge conflicts, e.g.:
+
+    '''
+    <<<<<<< old_file
+    old stuff
+    ||||||| orig_file
+    orig stuff
+    =======
+    new stuff
+    >>>>>>> new_file
+    '''
+
+    Write the result to `dest_file` if it is specified.
+    Return the text of the diff on success, None on failure.
+    """
+
+    diff, ret = utils.sbacktick(["diff3", "-m", old_file, orig_file, new_file])
+    if not (ret == 0 or ret == 1):
+        logging.warning("Error diffing %s %s %s: diff3 returned %d",
+                        old_file, orig_file, new_file, ret)
+        return
+
+    if dest_file:
+        utils.unslurp(dest_file, diff)
+        logging.info("Difference between %s, %s, and %s written to %s",
+                     old_file, orig_file, new_file, dest_file)
+
+    return diff
+
+
+def diff_spec(srpm, osg_dir, want_diff3=False):
+    """Do a 2- or 3-way diff between spec files found in the osg/
+     directory, and the new upstream SRPM. If a 3-way diff is requested,
+     also look at the spec file from the previous upstream SRPM. The
+     osg/ directory must exist.
+
+    The files that will be created or changed are:
+    - $spec.old  : spec file from the osg/ dir before import
+    - $spec.new  : spec file from the new upstream SRPM
+    - $spec.orig : spec file from the old upstream SRPM (3-way only)
+    - $spec      : combined spec file with differences separated by markers
+
+    """
+    if not os.path.isdir(osg_dir) or not glob.glob(os.path.join(osg_dir, '*')):
+        logging.error("No osg/ dir found or no spec files in osg/ dir -- nothing to diff.")
+        logging.error("To extract the spec file, run with -e instead.")
+        sys.exit(1)
+
+    utils.pushd(osg_dir)
+    try:
+        srpm = os.path.abspath(srpm)
+
+        spec_name = get_spec_name_in_srpm(srpm)
+        spec_name_old = spec_name + ".old"
+        spec_name_new = spec_name + ".new"
+
+        if not os.path.exists(spec_name):
+            logging.info("No old spec file matching %s - the spec file might have been renamed.",
+                         spec_name)
+            logging.info("Extracting new upstream spec file as %s", spec_name)
+            extract_from_rpm(srpm, spec_name)
+            return
+
+        logging.info("OSG spec file found matching %s, saving to %s",
+                     spec_name, spec_name_old)
+        shutil.move(spec_name, spec_name_old)
+
+        logging.info("Extracting new upstream spec file as %s", spec_name_new)
+        extract_from_rpm(srpm, spec_name)
+        shutil.move(spec_name, spec_name_new)
+
+        if want_diff3:
+            spec_name_orig = spec_name + ".orig"
+            if os.path.exists(spec_name_orig):
+                # Use `diff3 -m` to takes the changes that turn spec_name_orig into
+                # spec_name_new, and applies these changes to spec_name_new.
+                # Put the results into spec_name.
+
+                diff3(spec_name_old, spec_name_orig, spec_name_new, spec_name)
+            else:
+                # This can happen if the package before import was an upstream
+                # tarball with osg-provided spec file, as opposed to an
+                # upstream SRPM with an osg-modified spec file.
+
+                logging.info("No original upstream spec file matching %s - doing a two-way diff instead.", spec_name)
+                diff2(spec_name_old, spec_name_new, spec_name)
         else:
-            old_dir = getcwd() # pushd
-            chdir(osg_dir)
-            specs = list(glob.glob("*.spec"))
-            for s in specs:
-                move(s, s + ".old")
-            checked_call("rpm2cpio '%s' | cpio -ivd '*.spec'" % abs_srpm, shell=True)
-            for s in specs:
-                if exists(s + ".old") and exists(s):
-                    move(s, s + ".new")
-                    print ("Old spec file found. Examine difference " +
-                           "between %s.old and %s.new and manually merge " +
-                           "changes.\nDiff follows:\n") % (s, s)
-                    unchecked_call(["diff", s + ".old", s + ".new"])
-            chdir(old_dir) # popd
-    elif extract_spec:
-        if not isdir(osg_dir):
-            checked_call(["svn", "mkdir", osg_dir])
-        old_dir = getcwd() # pushd
-        chdir(osg_dir)
-        checked_call("rpm2cpio '%s' | cpio -ivd '*.spec'" % abs_srpm, shell=True)
-        checked_call("svn add *.spec", shell=True)
-        chdir(old_dir) # popd
+            diff2(spec_name_old, spec_name_new, spec_name)
+
+    finally:
+        utils.popd()
+
+
+def extract_spec(srpm, osg_dir):
+    """Extract the spec file from the SRPM, put it into an osg/ dir,
+    and add both the osg/ dir and the spec file to SVN, if necessary.
+    An existing spec file will be moved out of the way, with a .old
+    extension, if necessary.
+    """
+    if not os.path.exists(osg_dir):
+        os.mkdir(osg_dir)
+        svn_safe_add(osg_dir)
+
+    utils.pushd(osg_dir)
+    try:
+        srpm = os.path.abspath(srpm)
+
+        spec_name = get_spec_name_in_srpm(srpm)
+
+        if os.path.exists(spec_name):
+            spec_name_old = spec_name + ".old"
+            logging.info("OSG spec file found matching %s, saving to %s",
+                         spec_name, spec_name_old)
+            shutil.move(spec_name, spec_name_old)
+
+        logging.info("Extracting new upstream spec file as %s", spec_name)
+        extract_from_rpm(srpm, spec_name)
+        svn_safe_add(spec_name)
+    finally:
+        utils.popd()
+
+
+def extract_orig_spec(osg_dir):
+    """Save a copy of the original upstream spec file from before the
+    import into the osg_dir
+    """
+    utils.pushd(osg_dir)
+    try:
+        utils.checked_call(['osg-build', 'prebuild', '..'])
+        spec_paths = list(glob.glob("../_upstream_srpm_contents/*.spec"))
+        for spec_path in spec_paths:
+            spec_name_orig = os.path.basename(spec_path) + '.orig'
+            logging.info("Saving original upstream spec file as %s",
+                         spec_name_orig)
+            shutil.copy(spec_path, spec_name_orig)
+    finally:
+        utils.popd()
 
 
 def move_to_cache(srpm, upstream_root):
     """Move the srpm to the upstream cache."""
     name, version = srpm_nvr(srpm)[0:2]
-    base_srpm = basename(srpm)
-    upstream_dir = opj(upstream_root, name, version)
-    safe_makedirs(upstream_dir)
-    dest_file = opj(upstream_dir, base_srpm)
-    if exists(dest_file):
-        unlink(dest_file)
-    move(srpm, dest_file)
+    base_srpm = os.path.basename(srpm)
+    upstream_dir = os.path.join(upstream_root, name, version)
+    utils.safe_makedirs(upstream_dir)
+    dest_file = os.path.join(upstream_dir, base_srpm)
+    if os.path.exists(dest_file):
+        os.unlink(dest_file)
+    shutil.move(srpm, dest_file)
 
 
 def main(argv=None):
     if argv is None:
         argv = sys.argv
-    try:
-        parser = OptionParser("""
-   %prog [options] <upstream-url>
+
+    parser = OptionParser("""
+    %prog [options] <upstream-url>
 
 %prog should be called from an SVN checkout and given the URL of an upstream SRPM.
 will create and populate the appropriate directories in SVN as well as
 downloading and putting the SRPM into the upstream cache.
 """)
+    try:
+        parser.set_defaults(extra_action=None)
+
         parser.add_option(
-            "-d", "--diff-spec", action="store_true",
-            help="Extract the spec file from the SRPM and put it into an "
-            "osg/ subdirectory under a new name. If a spec file already "
-            "exists, diff the two.")
+            "-d", "--diff-spec", "-2", action="store_const", dest='extra_action', const=EXTRA_ACTION_DIFF_SPEC,
+            help="Perform a two-way diff between the new upstream spec file and the OSG spec file. "
+            "The new upstream spec file will be written to SPEC.new, and the OSG spec file will be "
+            "written to SPEC.old; the differences will be written to SPEC. You will have to edit "
+            "SPEC to resolve the differences.")
         parser.add_option(
-            "-e", "--extract-spec", action="store_true",
-            help="Extract the spec file from the SRPM and put it into an "
-            "osg/ subdirectory.")
+            "-e", "--extract-spec", action="store_const", dest='extra_action', const=EXTRA_ACTION_EXTRACT_SPEC,
+            help="Extract the spec file from the SRPM and put it into an osg/ subdirectory.")
         parser.add_option(
             "--loglevel",
-            help="The level of logging the script should do. " +
+            help="The level of logging the script should do. "
             "Valid values are DEBUG,INFO,WARNING,ERROR,CRITICAL")
         parser.add_option(
             "-o", "--output",
@@ -183,7 +414,13 @@ downloading and putting the SRPM into the upstream cache.
             "-p", "--provider",
             help="Who provided the SRPM being imported. For example, 'epel'. "
             "This is used to name the .source file in the 'upstream' directory. "
-            "The default is 'epel' if the SPRM is from EPEL, 'emi' if the SRPM is from EMI, and 'developer' otherwise.")
+            "If unspecified, guess based on the URL, and use 'developer' as the fallback.")
+        parser.add_option(
+            "-3", "--diff3-spec", action="store_const", dest='extra_action', const=EXTRA_ACTION_DIFF3_SPEC,
+            help="Perform a three-way diff between the original upstream spec file, the OSG spec file, "
+            "and the new upstream spec file. These spec files will be written to SPEC.orig, "
+            "SPEC.old, and SPEC.new, respectively; a merged result will be written to SPEC."
+            "You will have to edit SPEC to resolve merge conflicts.")
         parser.add_option(
             "-u", "--upstream", default=DEFAULT_UPSTREAM_ROOT,
             help="The base directory to put the upstream sources under. "
@@ -198,23 +435,21 @@ downloading and putting the SRPM into the upstream cache.
                 raise UsageError("Invalid log level")
         else:
             loglevel = DEFAULT_LOG_LEVEL
-        logging.basicConfig(format="%(levelname)s:" +
-                            basename(sys.argv[0]) +
-                            ":%(message)s", level=loglevel)
-        
+        logging.basicConfig(format=" >> %(message)s", level=loglevel)
+
         try:
             upstream_url = pos_args[0]
         except IndexError:
             raise UsageError("Required argument <upstream-url> not provided")
 
-        if unchecked_call("svn info &>/dev/null", shell=True):
+        if utils.unchecked_call("svn info &>/dev/null", shell=True):
             raise Error("Must be called from an svn checkout!")
 
         if not re.match(r'(http|https|ftp):', upstream_url):
             raise UsageError("upstream-url is not a valid url")
-        
+
         srpm = download_srpm(upstream_url, options.output)
-        make_svn_tree(srpm, upstream_url, options.extract_spec, options.diff_spec, options.provider)
+        make_svn_tree(srpm, upstream_url, options.extra_action, options.provider)
         move_to_cache(srpm, options.upstream)
 
     except UsageError, e:
@@ -227,11 +462,11 @@ downloading and putting the SRPM into the upstream cache.
         print >>sys.stderr, "Interrupted"
         return 3
     except Error, e:
-        critical(str(e))
-        debug(e.traceback)
+        logging.critical(str(e))
+        logging.debug(e.traceback)
     except Exception, e:
-        critical("Unhandled exception: %s", str(e))
-        critical(format_exc())
+        logging.critical("Unhandled exception: %s", str(e))
+        logging.critical(traceback.format_exc())
         return 1
 
     return 0

--- a/osgbuild/utils.py
+++ b/osgbuild/utils.py
@@ -390,3 +390,32 @@ def print_table(columns_by_header):
 def is_url(location):
     return re.match(r'[-a-z+]+://', location)
 
+
+# Functions for manipulating a directory stack in the style of bash
+# pushd/popd.
+__dir_stack = []
+
+def pushd(new_dir):
+    """Change the current working directory to `new_dir`, and push the
+    old one onto the directory stack `__dir_stack`.
+    """
+    global __dir_stack
+
+    old_dir = os.getcwd()
+    os.chdir(new_dir)
+    __dir_stack.append(old_dir)
+
+
+def popd():
+    """Change to the topmost directory in the directory stack
+    `__dir_stack` and pop the stack.  Note: the stack will be
+    popped even if the chdir fails.
+
+    Raise `IndexError` if the stack is empty.
+    """
+    global __dir_stack
+
+    try:
+        os.chdir(__dir_stack.pop())
+    except IndexError:
+        raise IndexError("Directory stack empty")


### PR DESCRIPTION
This triggered a major restructuring of osg-import-srpm, which had been
coming for a while.  Some highlights are:

- Create the new .source file _after_ doing the diff/extract.  The diff
  is the part that's most likely to fail for some reason, so this change
  keeps the dir from being in a half-merged state.

- Use normal imports instead of qualified imports, e.g.
  "import os.path; os.path.abspath(...)" instead of
  "from os.path import abspath; abspath(...)".

- Add the 'fedora' and 'globus' providers (for naming the .source
  files).

- Extract the specific spec file instead of using *.spec.  This ends up
  being safer for manipulating the spec file afterwards, though may
  break if the SRPM contains multiple spec files -- something that
  shouldn't happen.

- Add pushd/popd functions to utils.  These behave like their
  corresponding bash builtins.