### PR TITLE
Fix test_rpmbuild and test_mock_auto_cfg

### DIFF
--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -299,10 +299,6 @@ class TestMock(XTestCase):
         return False
 
 
-    def test_mock_auto_cfg(self):
-        if self.check_for_mock_group():
-            checked_osg_build(["mock", self.pkg_dir])
-
     def test_mock_koji_cfg(self):
         if self.check_for_mock_group():
             checked_osg_build(["mock", self.pkg_dir, "--el6", "--mock-config-from-koji=osg-3.2-el6-build"])

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -142,7 +142,7 @@ class TestRpmbuild(XTestCase):
         try:
             self.assertRegexpMatches(
                 out,
-                r'(?ms)INFO:osg-build:The following RPM[(]s[)] have been created:\n'
+                r'(?ms) >> The following RPM[(]s[)] have been created:\n'
                 r'[^\n]+'
                 r'yum-remove-osg-1[.]0-0[.]2[.]osg[.]el\d[.]noarch[.]rpm',
                 "rpm created message not found")


### PR DESCRIPTION
In the unit tests, `test_rpmbuild` started failing due to the log message format change; fix that.
`test_mock_auto_cfg` tests a broken feature (the auto-generated config references 3.1 and EL5), so remove it.  (The feature will be removed later, once I figure out the semantics for the replacement).