### PR TITLE
Add --update option to osg-import-srpm

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Unreleased
 - Don't print "Implicitly building for el..." message unless in verbose mode
+- Add update action (--update or -U) to osg-import-srpm
 
 * Fri Aug 05 2016 Mátyás Selmeci <matyas@cs.wisc.edu> - 1.7.0
 - Add three-way diff functionality (--diff3 or -3) to osg-import-srpm

--- a/osgbuild/importer.py
+++ b/osgbuild/importer.py
@@ -20,6 +20,7 @@ DEFAULT_LOG_LEVEL = logging.INFO
 EXTRA_ACTION_DIFF_SPEC = 'diff_spec'
 EXTRA_ACTION_EXTRACT_SPEC = 'extract_spec'
 EXTRA_ACTION_DIFF3_SPEC = 'diff3_spec'
+EXTRA_ACTION_UPDATE = 'update'
 
 PROVIDER_PATTERNS = [
     (r'emisoft\.web\.cern\.ch'         , 'emi')    ,
@@ -100,7 +101,8 @@ def make_svn_tree(srpm, url, extra_action=None, provider=None):
         diff_spec(abs_srpm, osg_dir, want_diff3=False)
     elif extra_action == EXTRA_ACTION_EXTRACT_SPEC:
         extract_spec(abs_srpm, osg_dir)
-    elif extra_action == EXTRA_ACTION_DIFF3_SPEC:
+    # HACK - this test is ugly
+    elif extra_action == EXTRA_ACTION_DIFF3_SPEC or (extra_action == EXTRA_ACTION_UPDATE and os.path.isdir(osg_dir)):
         if os.path.isdir(osg_dir):
             extract_orig_spec(osg_dir)
         diff_spec(abs_srpm, osg_dir, want_diff3=True)
@@ -425,6 +427,11 @@ downloading and putting the SRPM into the upstream cache.
             "-u", "--upstream", default=DEFAULT_UPSTREAM_ROOT,
             help="The base directory to put the upstream sources under. "
             "Default: %default")
+        parser.add_option(
+            "-U", "--update", action="store_const", dest='extra_action', const=EXTRA_ACTION_UPDATE,
+            help="If there is an osg/ directory, do a 3-way diff like --diff3-spec.  Otherwise just update"
+            " the .source file in the 'upstream' directory."
+        )
 
         options, pos_args = parser.parse_args(argv[1:])
 


### PR DESCRIPTION
If `--update` (or `-U`) is specified, `osg-import-srpm` will update the `upstream/source` file as usual, and then diff3 the spec file in `osg/` if it exists.  This way, you can run `osg-import-srpm -U` on any package without having to first check if it has an `osg` dir or not.

This change will make it more likiely for people to run `osg-import-srpm` in the package directory (e.g. in `trunk/foo`); until now, `osg-import-srpm` needed to be run in the svn branch instead (e.g. `trunk`).  Handle that condition better.