### PR TITLE
Dver cleanup

### DIFF
--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -83,21 +83,21 @@ DEFAULT_BUILDOPTS_COMMON = {
 }
 
 DEFAULT_BUILDOPTS_BY_DVER = {
-    '5': {
+    'el5': {
         'distro_tag': 'osg.el5',
         'koji_tag': None,
         'koji_target': None,
         'redhat_release': '5',
         'repo': 'osg',
     },
-    '6': {
+    'el6': {
         'distro_tag': 'osg.el6',
         'koji_tag': None,
         'koji_target': None,
         'redhat_release': '6',
         'repo': 'osg',
     },
-    '7': {
+    'el7': {
         'distro_tag': 'osg.el7',
         'koji_tag': None,
         'koji_target': None,
@@ -107,22 +107,22 @@ DEFAULT_BUILDOPTS_BY_DVER = {
 }
 
 REPO_HINTS_STATIC = {
-    'osg': {'target': 'osg-el%s', 'tag': 'osg-el%s'},
-    'upcoming': {'target': 'osg-upcoming-el%s', 'tag': 'osg-el%s'},
-    'internal': {'target': 'osg-el%s-internal', 'tag': 'osg-el%s'},
-    'hcc': {'target': 'hcc-el%s', 'tag': 'hcc-el%s'},
-    'uscms': {'target': 'uscms-el%s', 'tag': 'uscms-el%s'},
-    'condor': {'target': 'condor-el%s', 'tag': 'condor-el%s'},
-    'perfsonar': {'target': 'perfsonar-el%s', 'tag': 'perfsonar-el%s'},
+    'osg': {'target': 'osg-%(dver)s', 'tag': 'osg-%(dver)s'},
+    'upcoming': {'target': 'osg-upcoming-%(dver)s', 'tag': 'osg-%(dver)s'},
+    'internal': {'target': 'osg-%(dver)s-internal', 'tag': 'osg-%(dver)s'},
+    'hcc': {'target': 'hcc-%(dver)s', 'tag': 'hcc-%(dver)s'},
+    'uscms': {'target': 'uscms-%(dver)s', 'tag': 'uscms-%(dver)s'},
+    'condor': {'target': 'condor-%(dver)s', 'tag': 'condor-%(dver)s'},
+    'perfsonar': {'target': 'perfsonar-%(dver)s', 'tag': 'perfsonar-%(dver)s'},
 }
 
-DEFAULT_DVERS = ['6', '7']
+DEFAULT_DVERS = ['el6', 'el7']
 DEFAULT_DVERS_BY_REPO = {
-    '3.2': ['5', '6'],
-    'osg-3.2': ['5', '6'],
-    '3.3': ['6', '7'],
-    'osg-3.3': ['6', '7'],
-    'internal': ['5', '6', '7'],
+    '3.2': ['el5', 'el6'],
+    'osg-3.2': ['el5', 'el6'],
+    '3.3': ['el6', 'el7'],
+    'osg-3.3': ['el6', 'el7'],
+    'internal': ['el5', 'el6', 'el7'],
 }
 DVERS = DEFAULT_BUILDOPTS_BY_DVER.keys()
 

--- a/osgbuild/srpm.py
+++ b/osgbuild/srpm.py
@@ -85,10 +85,10 @@ class SRPMBuild(object):
             "osg 1",
         ]
         for dver in DVERS:
-            if dver == rhel:
-                defines.append("el%s 1" % dver)
+            if dver == 'el' + rhel:
+                defines.append("%s 1" % dver)
             else:
-                defines.append("el%s 0" % dver)
+                defines.append("%s 0" % dver)
         if rhel == '5':
             defines += [
                 "_source_filedigest_algorithm 1",

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -434,27 +434,28 @@ class TestMisc(XTestCase):
         buildopts_el = dict()
         build_el = dict()
         defines_el = dict()
-        for dver in ['5', '6']:
+        for dver in ['el5', 'el6']:
+            rhel = dver[2:]
             buildopts_el[dver] = DEFAULT_BUILDOPTS_COMMON.copy()
             buildopts_el[dver]['redhat_release'] = dver
             buildopts_el[dver].update(DEFAULT_BUILDOPTS_BY_DVER[dver])
             build_el[dver] = srpm.SRPMBuild(".", buildopts_el[dver], None, None)
             defines_el[dver] = build_el[dver].get_rpmbuild_defines(True)
-            self.assertTrue("--define=rhel %s" % dver in defines_el[dver],
-                            "%%rhel not set correctly for el%s build" % dver)
+            self.assertTrue("--define=rhel %s" % rhel in defines_el[dver],
+                            "%%rhel not set correctly for %s build" % dver)
 
-        self.assertTrue('--define=el5 1' in defines_el['5'],
+        self.assertTrue('--define=el5 1' in defines_el['el5'],
                         "%el5 not set for el5 build")
-        self.assertTrue('--define=el6 0' in defines_el['5'],
+        self.assertTrue('--define=el6 0' in defines_el['el5'],
                         "%el6 not unset for el5 build")
 
-        self.assertTrue('--define=el6 1' in defines_el['6'],
+        self.assertTrue('--define=el6 1' in defines_el['el6'],
                         "%el6 not set for el6 build")
-        self.assertTrue('--define=el5 0' in defines_el['6'],
+        self.assertTrue('--define=el5 0' in defines_el['el6'],
                         "%el5 not unset for el6 build")
 
         self.assertTrue('--define=_source_filedigest_algorithm 1' in
-                        defines_el['5'],
+                        defines_el['el5'],
                         "filedigest algorithm not set for el5 build")
 
 


### PR DESCRIPTION
Internal code fix: make the term "dver" be used consistently throughout the code. In some places, dver was the OS release with "el" before it (e.g. "el5", "el6"), and in other places, dver was just the OS release (e.g. "5", "6"). The term "dver" now means the former, and the term "redhat release" or "rhel" is used for the latter.

Some dictionaries used to be keyed by redhat release; for consistency, make them all keyed by dver instead.