### PR TITLE
Improve osg-koji setup UX

### DIFF
--- a/osg-koji
+++ b/osg-koji
@@ -21,7 +21,7 @@ from osgbuild.utils import (
     safe_make_backup,
     safe_makedirs,
     slurp,
-    unslurp)
+    unslurp, shell_quote)
 
 
 
@@ -199,7 +199,7 @@ def setup_koji_config_file():
             ask_yn("""\
 Koji configuration file '%s' already exists.
 Overwrite it with a new config file? Unless you have made changes to the file,
-you should say 'yes'.
+you should say 'y'.
 """ % new_koji_config_path)):
         safe_make_backup(new_koji_config_path)
         shutil.copy(find_file("osg-koji-home.conf", DATA_FILE_SEARCH_PATH), new_koji_config_path)
@@ -237,9 +237,10 @@ def copy_old_client_cert(new_client_cert_path):
 def create_client_cert_from_cert_and_key(new_client_cert_path, user_cert, user_key):
     safe_make_backup(new_client_cert_path)
     # Concatenate the cert and key; make sure there is a newline between them
-    os.system("(cat %r; echo; cat %r) > %r" % (user_cert, user_key, new_client_cert_path))
+    os.system("(cat %s; echo; cat %s) > %s" % (shell_quote(user_cert), shell_quote(user_key),
+                                               shell_quote(new_client_cert_path)))
     # Convert DOS line endings; use sed because dos2unix might not be installed
-    os.system("sed -i -e 's/\015$//g' %r" % new_client_cert_path)
+    os.system("sed -i -e 's/\015$//g' %s" % shell_quote(new_client_cert_path))
 
 @with_safe_umask
 def create_client_symlink_to_proxy(new_client_cert_path):

--- a/osg-koji
+++ b/osg-koji
@@ -256,10 +256,10 @@ def setup_koji_client_cert(user_cert, user_key):
     new_client_cert_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, CLIENT_CERT_FILE)
     if (os.path.lexists(new_client_cert_path) and
             not ask_yn("""
-Client cert file '%s' already exists.
-Recreate it? Say yes if you have trouble logging in via the command-line
-tools, if you got a new certificate, or want to change between using a
-cert/key pair and using a grid proxy.
+Client certificate file '%s' already exists. Do you want to recreate it now?
+Enter yes if you have trouble logging in via the command-line tools, if you
+got a new certificate, or want to use a grid certificate/key pair instead of
+a grid proxy or vice versa.
 """ % new_client_cert_path)):
 
         print "Not writing client cert file %r" % new_client_cert_path
@@ -271,16 +271,16 @@ cert/key pair and using a grid proxy.
             os.path.isfile(OLD_CLIENT_CERT_FILE)):
 
         if ask_yn("""
-You already have a client cert at '%s'.
+You already have a client certificate at '%s'.
 Reuse that file?
 """ % OLD_CLIENT_CERT_FILE):
             copy_old_client_cert(new_client_cert_path)
             return
 
     if ask_yn("""
-Set up symlink to grid proxy? If you do this, you can use grid-proxy-init or
-voms-proxy-init to create a proxy and not have to type your password in as
-often.
+Symlink to expected grid proxy location? Doing so means you can use a grid
+proxy (from grid-proxy-init or voms-proxy-init) for authentication and
+thereby not need to type your password in as often.
 """):
         create_client_symlink_to_proxy(new_client_cert_path)
         print "Proxy symlink created. If using voms-proxy-init, be sure to request an RFC-style proxy (pass -rfc)"
@@ -358,7 +358,7 @@ tools by running:
 
     %s list-permissions --mine
 
-(Run grid-proxy-init first, if necessary).
+If you authenticate with a proxy, be sure to have a valid one first.
 """ % (PROGRAM_NAME)
 
             elif argv[1] == "help":

--- a/osg-koji
+++ b/osg-koji
@@ -195,10 +195,10 @@ def setup_koji_config_file():
     """Create the koji config file (if needed)."""
     new_koji_config_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, KOJI_CONFIG_FILE)
     if (not os.path.exists(new_koji_config_path) or
-            ask_yn("""\
+            ask_yn("""
 Koji configuration file '%s' already exists.
 Overwrite it with a new config file? Unless you have made changes to the file,
-you should say 'y'.
+you should say yes.
 """ % new_koji_config_path)):
         safe_make_backup(new_koji_config_path)
         shutil.copy(find_file("osg-koji-home.conf", DATA_FILE_SEARCH_PATH), new_koji_config_path)
@@ -255,9 +255,9 @@ def setup_koji_client_cert(user_cert, user_key):
     """Create or copy the client cert file (if needed)."""
     new_client_cert_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, CLIENT_CERT_FILE)
     if (os.path.lexists(new_client_cert_path) and
-            not ask_yn("""\
+            not ask_yn("""
 Client cert file '%s' already exists.
-Recreate it? Say 'y' if you have trouble logging in via the command-line
+Recreate it? Say yes if you have trouble logging in via the command-line
 tools, if you got a new certificate, or want to change between using a
 cert/key pair and using a grid proxy.
 """ % new_client_cert_path)):
@@ -270,14 +270,14 @@ cert/key pair and using a grid proxy.
             not os.path.samefile(KOJI_USER_CONFIG_DIR, OSG_KOJI_USER_CONFIG_DIR)) and
             os.path.isfile(OLD_CLIENT_CERT_FILE)):
 
-        if ask_yn("""\
+        if ask_yn("""
 You already have a client cert at '%s'.
 Reuse that file?
 """ % OLD_CLIENT_CERT_FILE):
             copy_old_client_cert(new_client_cert_path)
             return
 
-    if ask_yn("""\
+    if ask_yn("""
 Set up symlink to grid proxy? If you do this, you can use grid-proxy-init or
 voms-proxy-init to create a proxy and not have to type your password in as
 often.
@@ -352,7 +352,7 @@ def main(argv=None):
             if argv[1] == "setup":
                 options = setup_parse_args(argv[2:])
                 run_setup(options.user_cert, options.user_key)
-                print """\
+                print """
 Setup is done. You may verify that you can log in via the command-line
 tools by running:
 

--- a/osg-koji
+++ b/osg-koji
@@ -307,6 +307,7 @@ If you wish to use grid proxy authentication, make a symlink from
 %(new_client_cert_path)r to your proxy. If using voms-proxy-init, be sure to
 request an RFC-style proxy (pass -rfc).
 """ % locals())
+    sys.exit(1)
 
 
 def run_setup(user_cert, user_key):
@@ -351,6 +352,15 @@ def main(argv=None):
             if argv[1] == "setup":
                 options = setup_parse_args(argv[2:])
                 run_setup(options.user_cert, options.user_key)
+                print """\
+Setup is done. You may verify that you can log in via the command-line
+tools by running:
+
+    %s list-permissions --mine
+
+(Run grid-proxy-init first, if necessary).
+""" % (PROGRAM_NAME)
+
             elif argv[1] == "help":
                 os.system("koji " + ' '.join(argv[1:]))
                 print EXTRA_HELP

--- a/osg-koji
+++ b/osg-koji
@@ -196,7 +196,12 @@ def setup_koji_config_file():
     """Create the koji config file (if needed)."""
     new_koji_config_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, KOJI_CONFIG_FILE)
     if (not os.path.exists(new_koji_config_path) or
-            ask_yn("Koji configuration file '" + new_koji_config_path + "' already exists. Recreate it?")):
+            ask_yn("""\
+Koji configuration file '%s' already exists.
+Overwrite it with a new config file? Unless you have made changes to the file,
+you should say 'yes'.
+""" % new_koji_config_path)):
+        safe_make_backup(new_koji_config_path)
         shutil.copy(find_file("osg-koji-home.conf", DATA_FILE_SEARCH_PATH), new_koji_config_path)
 
 

--- a/osg-koji
+++ b/osg-koji
@@ -201,16 +201,12 @@ def setup_koji_config_file():
 
 
 def setup_koji_server_cert():
-    """Create the koji server cert file (if needed)."""
+    """Create the koji server cert file."""
     new_server_cert_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, SERVER_CERT_FILE)
-    if (not os.path.exists(new_server_cert_path) or
-            ask_yn("Server cert file '" + new_server_cert_path + "' already exists. Recreate it?")):
-        working_dir = tempfile.mkdtemp(prefix='osg-koji-setup-')
-        safe_make_backup(new_server_cert_path)
-        shutil.copy(create_ca_bundle(working_dir), new_server_cert_path)
-        shutil.rmtree(working_dir, ignore_errors=True)
-    else:
-        print "Not writing server cert file %r" % new_server_cert_path
+    working_dir = tempfile.mkdtemp(prefix='osg-koji-setup-')
+    safe_make_backup(new_server_cert_path)
+    shutil.copy(create_ca_bundle(working_dir), new_server_cert_path)
+    shutil.rmtree(working_dir, ignore_errors=True)
 
 
 def with_safe_umask(function_to_wrap):

--- a/osg-koji
+++ b/osg-koji
@@ -256,7 +256,12 @@ def setup_koji_client_cert(user_cert, user_key):
     """Create or copy the client cert file (if needed)."""
     new_client_cert_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, CLIENT_CERT_FILE)
     if (os.path.exists(new_client_cert_path) and
-            not ask_yn("Client cert file '" + new_client_cert_path + "' already exists. Recreate it?")):
+            not ask_yn("""\
+Client cert file '%s' already exists.
+Recreate it? Say 'y' if you have trouble logging in via the command-line
+tools, if you got a new certificate, or want to change between using a
+cert/key pair and using a grid proxy.
+""" % new_client_cert_path)):
 
         print "Not writing client cert file %r" % new_client_cert_path
         return
@@ -266,11 +271,18 @@ def setup_koji_client_cert(user_cert, user_key):
             not os.path.samefile(KOJI_USER_CONFIG_DIR, OSG_KOJI_USER_CONFIG_DIR)) and
             os.path.isfile(OLD_CLIENT_CERT_FILE)):
 
-        if ask_yn("Copy client cert from '" + OLD_CLIENT_CERT_FILE + "' ?"):
+        if ask_yn("""\
+You already have a client cert at '%s'.
+Reuse that file?
+""" % OLD_CLIENT_CERT_FILE):
             copy_old_client_cert(new_client_cert_path)
             return
 
-    if ask_yn("Set up symlink to grid proxy?"):
+    if ask_yn("""\
+Set up symlink to grid proxy? If you do this, you can use grid-proxy-init or
+voms-proxy-init to create a proxy and not have to type your password in as
+often.
+"""):
         create_client_symlink_to_proxy(new_client_cert_path)
         print "Proxy symlink created. If using voms-proxy-init, be sure to request an RFC-style proxy (pass -rfc)"
         return

--- a/osg-koji
+++ b/osg-koji
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-import glob
 import os
 import shutil
 import sys
@@ -17,11 +16,11 @@ from osgbuild.utils import (
     ask_yn,
     backtick,
     find_file,
-    checked_call,
     safe_make_backup,
     safe_makedirs,
+    shell_quote,
     slurp,
-    unslurp, shell_quote)
+    unslurp)
 
 
 

--- a/osg-koji
+++ b/osg-koji
@@ -254,7 +254,7 @@ def create_client_symlink_to_proxy(new_client_cert_path):
 def setup_koji_client_cert(user_cert, user_key):
     """Create or copy the client cert file (if needed)."""
     new_client_cert_path = os.path.join(OSG_KOJI_USER_CONFIG_DIR, CLIENT_CERT_FILE)
-    if (os.path.exists(new_client_cert_path) and
+    if (os.path.lexists(new_client_cert_path) and
             not ask_yn("""\
 Client cert file '%s' already exists.
 Recreate it? Say 'y' if you have trouble logging in via the command-line


### PR DESCRIPTION
For SOFTWARE-2455. Improve the confirmation messages for osg-koji setup to make it easier to use. In one case (overwriting the server cert), the remove the confirmation message.
Also provide the user with a command to test their setup.