### PR TITLE
Add support for git repos in a RPM source

### DIFF
--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -46,7 +46,7 @@ def process_json_url(line, destdir):
     tag = json_contents.get("tag")
     if not tag:
         raise Error("No package tag specified: %s" % line)
-    dest_file = str("%s-%s.tar" % (name, tag))
+    dest_file = str("%s-%s.tar.gz" % (name, tag))
     full_dest_file = os.path.join(destdir, dest_file)
     prefix = str("%s-%s" % (name, tag))
     git_hash = json_contents.get("hash")
@@ -67,17 +67,14 @@ def process_json_url(line, destdir):
         sha1 = output.split()[0]
         if sha1 != git_hash:
             raise Error("Repository hash %s corresponding to tag %s does not match expected hash %s" % (sha1, tag, git_hash))
-        rc = subprocess.call(["git", "archive", "--prefix=%s/" % prefix, str(git_hash), "--output=%s" % os.path.join(destdir, dest_file)])
+        rc = subprocess.call(["git", "archive", "--format=tgz", "--prefix=%s/" % prefix, str(git_hash), "--output=%s" % os.path.join(destdir, dest_file)])
         if rc:
             raise Error("Failed to create an archive of hash %s" % git_hash)
-        rc = subprocess.call(["gzip", full_dest_file])
-        if rc:
-            raise Error("Failed to compress archive at %s" % full_dest_file)
     finally:
         os.chdir(orig_dir)
         shutil.rmtree(checkout_dir)
 
-    return full_dest_file + ".gz"
+    return full_dest_file
 
 def process_dot_source(cache_prefix, sfilename, destdir):
     """Read a .source file, fetch any files mentioned in it from the


### PR DESCRIPTION
This commit adds support for providing a verified git tag as a source for an RPM.

The line in the source file should have a format similar to the following:

```
{"type": "git", \
 "url": "https://github.com/opensciencegrid/cvmfs-config-osg.git", \
 "tag": "v0.1",
 "hash": "e2b54cd1b94c9e3eaee079490c9d85f193c52249"}
```

(should be on the same line in the file; line continuations added for readability.)

This results in a tarball named `cvmfs-config-osg-v0.1.tar.gz` that:
  - File contents are prefixed with directory `cvmfs-config-osg-v0.1/`
  - Contents correspond to the git tag `v0.1`
  - The tag `v0.1` is verified to be the same as hash `e2b54cd1b94c9e3eaee079490c9d85f193c52249` in the repository.

This provides end-to-end verification of the contents of source tarballs for git-based projects.