### PR TITLE
don't dump traceback for normal errors

### DIFF
--- a/osg-promote
+++ b/osg-promote
@@ -1,7 +1,12 @@
 #!/usr/bin/env python2
 import sys
+from osgbuild import error
 from osgbuild import promoter
 
 if __name__ == "__main__":
-    sys.exit(promoter.main(sys.argv))
+    try:
+        sys.exit(promoter.main(sys.argv))
+    except error.Error, e:
+        print >>sys.stderr, e
+        sys.exit(1)
 

--- a/osgbuild/promoter.py
+++ b/osgbuild/promoter.py
@@ -745,4 +745,8 @@ def _get_route_dvers_pairs(routenames, valid_routes, extra_dvers, no_dvers, only
 
 
 if __name__ == "__main__":
-    sys.exit(main(sys.argv))
+    try:
+        sys.exit(main(sys.argv))
+    except error.Error, e:
+        print >>sys.stderr, e
+        sys.exit(1)


### PR DESCRIPTION
when, say, my cert has expired, that's all i need to know.  it feels
like something went spectacularly wrong when osg-promote explodes with
a traceback, even though it's really a simple and normal error.