### PR TITLE
Base default promotion routes on 3.4 instead of 3.3

### DIFF
--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -132,6 +132,6 @@ dvers=el6 el7
 extra_dvers=
 
 [aliases]
-contrib=3.3-contrib
-prerelease=3.3-prerelease
-testing=3.3-testing
+contrib=3.4-contrib
+prerelease=3.4-prerelease
+testing=3.4-testing

--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -111,9 +111,9 @@ dvers=el5 el6
 extra_dvers=
 
 [route goc-itb]
-from=osg-3.3-%s-development
+from=osg-3.4-%s-development
 to=goc-%s-itb
-repotag=osg33
+repotag=osg34
 dvers=el6 el7
 extra_dvers=
 
@@ -127,7 +127,7 @@ extra_dvers=
 [route goc-production]
 from=goc-%s-itb
 to=goc-%s-production
-repotag=osg33
+repotag=osg34
 dvers=el6 el7
 extra_dvers=
 


### PR DESCRIPTION
These are the "contrib", "prerelease", and "testing" aliases, and the goc routes.