### PR TITLE
Python 3 support

### DIFF
--- a/koji-blame
+++ b/koji-blame
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+from __future__ import print_function
 import re
 import sys
 import datetime
@@ -93,7 +94,7 @@ def format_history_item(history_item, mode):
 
 def main(argv):
     if len(argv) < 2 or argv[1] in ('-h', '--help'):
-        print "Usage: koji-blame <PACKAGE or TAG or BUILD>"
+        print("Usage: koji-blame <PACKAGE or TAG or BUILD>")
         return 2
 
     if not utils.which('osg-koji'):

--- a/osg-build
+++ b/osg-build
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 "Load and run the main osg-build script"
 # pylint: disable=C0103
+from __future__ import print_function
 import os
 import sys
 import traceback
@@ -14,8 +15,8 @@ log = main.log
 try:
     sys.exit(main.main(sys.argv))
 except UsageError as err:
-    print >> sys.stderr, str(err)
-    print >> sys.stderr, """\
+    print(str(err), file=sys.stderr)
+    print("""\
 Type %(prog)s --help for usage info.
 
 Common usage patterns follow:
@@ -43,31 +44,31 @@ To submit build(s) for EL6 or EL7 only:
 
 Also see the documentation at:
     https://twiki.grid.iu.edu/bin/view/SoftwareTeam/OSGBuildTools
-""" % {'prog': os.path.basename(sys.argv[0])}
+""" % {'prog': os.path.basename(sys.argv[0])}, file=sys.stderr)
     sys.exit(2)
 except SystemExit as err:
     raise
 except KeyboardInterrupt:
-    print >> sys.stderr, ""
-    print >> sys.stderr, "-" * 79
-    print >> sys.stderr, "Interrupted"
-    print >> sys.stderr, "-" * 79
+    print("", file=sys.stderr)
+    print("-" * 79, file=sys.stderr)
+    print("Interrupted", file=sys.stderr)
+    print("-" * 79, file=sys.stderr)
     sys.exit(3)
 except Error as err:
-    print >> sys.stderr, "-" * 79
-    print >> sys.stderr, str(err)
-    print >> sys.stderr, "-" * 79
+    print("-" * 79, file=sys.stderr)
+    print(str(err), file=sys.stderr)
+    print("-" * 79, file=sys.stderr)
     log.debug("Full traceback follows:")
     log.debug(traceback.format_exc())
     sys.exit(4)
 except Exception as err:
-    print >> sys.stderr, "-" * 79
-    print >> sys.stderr, "An unhandled exception of type %s occurred:" % type_of_error(err)
-    print >> sys.stderr, str(err)
-    print >> sys.stderr, "Please send a bug report with as much information"
-    print >> sys.stderr, "about the circumstances as you can provide to:"
-    print >> sys.stderr, constants.BUGREPORT_EMAIL
-    print >> sys.stderr, "-" * 79
-    print >> sys.stderr, "Full traceback follows:"
+    print("-" * 79, file=sys.stderr)
+    print("An unhandled exception of type %s occurred:" % type_of_error(err), file=sys.stderr)
+    print(str(err), file=sys.stderr)
+    print("Please send a bug report with as much information", file=sys.stderr)
+    print("about the circumstances as you can provide to:", file=sys.stderr)
+    print(constants.BUGREPORT_EMAIL, file=sys.stderr)
+    print("-" * 79, file=sys.stderr)
+    print("Full traceback follows:", file=sys.stderr)
     traceback.print_exc()
     sys.exit(1)

--- a/osg-import-srpm
+++ b/osg-import-srpm
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import sys
 from osgbuild import importer
 

--- a/osg-koji
+++ b/osg-koji
@@ -6,7 +6,10 @@ import re
 import shutil
 import sys
 import tempfile
-import urllib2
+try:
+    from six.moves import urllib
+except ImportError:
+    from osgbuild.six.moves import urllib
 
 from collections import namedtuple
 from optparse import OptionParser
@@ -24,6 +27,7 @@ from osgbuild.utils import (
     safe_makedirs,
     shell_quote,
     slurp,
+    to_str,
     unslurp)
 
 
@@ -169,7 +173,7 @@ def checked_download(dest, url):
     else:
         realdest = dest
     try:
-        urlhandle = urllib2.urlopen(url)
+        urlhandle = urllib.request.urlopen(url)
         realdesthandle = open(realdest, 'w')
         realdesthandle.write(urlhandle.read())
         realdesthandle.close()

--- a/osg-promote
+++ b/osg-promote
@@ -1,4 +1,5 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
+from __future__ import print_function
 import logging
 import sys
 from osgbuild import error
@@ -15,7 +16,7 @@ log.addHandler(log_consolehandler)
 if __name__ == "__main__":
     try:
         sys.exit(promoter.main(sys.argv))
-    except error.Error, e:
-        print >>sys.stderr, e
+    except error.Error as e:
+        print(e, file=sys.stderr)
         sys.exit(1)
 

--- a/osgbuild/clientcert.py
+++ b/osgbuild/clientcert.py
@@ -1,10 +1,11 @@
+from __future__ import absolute_import
 import re
 import os
 import time
 
 from datetime import datetime
-from osgbuild.error import ClientCertError
-from osgbuild import utils
+from .error import ClientCertError
+from . import utils
 
 class ClientCert(object):
     __slots__ = ['filename', 'first_commonname', 'startdate', 'enddate']

--- a/osgbuild/error.py
+++ b/osgbuild/error.py
@@ -47,7 +47,7 @@ class FileNotFoundError(Error):
 class ProgramNotFoundError(Error):
     def __init__(self, program):
         msg = "Couldn't find required program '%s'." % program
-        if program.find("/") == -1:
+        if "/" not in program:
             Error.__init__(self, msg + " $PATH was:\n%s" % os.environ['PATH'])
         else:
             Error.__init__(self, msg)

--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -13,7 +13,11 @@ import re
 import os
 import tempfile
 import shutil
-import urllib2
+try:
+    from six.moves import urllib
+except ImportError:
+    from .six.moves import urllib
+
 
 from .constants import *
 from .error import Error, GlobNotFoundError
@@ -130,12 +134,12 @@ def process_dot_source(cache_prefix, sfilename, destdir):
 
             log.info('Retrieving ' + uri)
             try:
-                handle = urllib2.urlopen(uri)
-            except urllib2.URLError as err:
+                handle = urllib.request.urlopen(uri)
+            except urllib.error.URLError as err:
                 raise Error("Unable to download %s\n%s" % (uri, str(err)))
             filename = os.path.join(destdir, basename)
             try:
-                with open(filename, 'w') as desthandle:
+                with open(filename, 'wb') as desthandle:
                     desthandle.write(handle.read())
             except EnvironmentError as err:
                 raise Error("Unable to save downloaded file to %s\n%s" % (filename, str(err)))

--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -4,6 +4,8 @@ the osg/ dir in the package.
 """
 
 # pylint: disable=W0614
+from __future__ import absolute_import
+from __future__ import print_function
 import fnmatch
 import logging
 import glob
@@ -13,9 +15,9 @@ import tempfile
 import shutil
 import urllib2
 
-from osgbuild.constants import *
-from osgbuild.error import Error, GlobNotFoundError
-from osgbuild import utils
+from .constants import *
+from .error import Error, GlobNotFoundError
+from . import utils
 
 log = logging.getLogger(__name__)
 

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -1,12 +1,13 @@
 """Helper functions for a git build."""
+from __future__ import absolute_import
+from __future__ import print_function
 import re
 import os
 import errno
 
-from osgbuild.error import Error, GitError
-from osgbuild import utils
-
-import osgbuild.constants as constants
+from .error import Error, GitError
+from . import utils
+from . import constants
 
 def is_git(package_dir):
     """Determine whether a given directory is part of a git repo."""
@@ -111,9 +112,9 @@ def is_uncommitted(package_dir):
     if err:
         raise GitError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     if out:
-        print "The following uncommitted changes exist:"
-        print out
-        print "Please commit these first."
+        print("The following uncommitted changes exist:")
+        print(out)
+        print("Please commit these first.")
         return True
 
     remote = get_current_branch_remote(package_dir)
@@ -191,7 +192,7 @@ def is_outdated(package_dir):
     if remote_hash == branch_hash:
         return False
 
-    print "Remote hash (%s) does not match local hash (%s) for branch %s." % (remote_hash, branch_hash, branch)
+    print("Remote hash (%s) does not match local hash (%s) for branch %s." % (remote_hash, branch_hash, branch))
     return True
 
 

--- a/osgbuild/importer.py
+++ b/osgbuild/importer.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import glob
 import logging
 import re
@@ -183,7 +184,7 @@ def get_spec_name_in_srpm(srpm):
     if ret != 0:
         raise Error("Unable to get list of spec files from %s" % srpm)
     try:
-        spec_name = filter(None, [x.strip() for x in out.split("\n")])[0]
+        spec_name = [_f for _f in [x.strip() for x in out.split("\n")] if _f][0]
     except IndexError:
         spec_name = None
 
@@ -470,12 +471,12 @@ downloading and putting the SRPM into the upstream cache.
 
     except UsageError as e:
         parser.print_help()
-        print >>sys.stderr, str(e)
+        print(str(e), file=sys.stderr)
         return 2
     except SystemExit as e:
         return e.code
     except KeyboardInterrupt:
-        print >>sys.stderr, "Interrupted"
+        print("Interrupted", file=sys.stderr)
         return 3
     except Error as e:
         logging.critical(str(e))

--- a/osgbuild/kojiinter.py
+++ b/osgbuild/kojiinter.py
@@ -12,8 +12,10 @@ import logging
 import re
 import os
 import time
-import urllib2
-from urllib2 import HTTPError
+try:
+    from six.moves import urllib
+except ImportError:
+    from .six.moves import urllib
 
 from .constants import *
 from . import clientcert
@@ -96,8 +98,8 @@ def download_koji_file(task_id, filename, destdir):
     url = KOJI_HUB + "/koji/getfile?taskID=%d&name=%s" % (task_id, filename)
     log.debug('Retrieving ' + url)
     try:
-        handle = urllib2.urlopen(url)
-    except HTTPError as err:
+        handle = urllib.request.urlopen(url)
+    except urllib.error.HTTPError as err:
         log.error('Error retrieving ' + url)
         log.error(str(err))
         raise
@@ -640,7 +642,7 @@ class KojiLibInter(object):
                             if not filename.endswith('src.rpm'):
                                 destsubdir = re.sub(r'-build', '', tag_name) + "-" + arch
                                 download_koji_file(task_id, filename, os.path.join(destdir, destsubdir))
-                    except (TypeError, AttributeError, HTTPError):
+                    except (TypeError, AttributeError, urllib.error.HTTPError):
                         # TODO More useful error message
                         log.warning("Unable to download files for task %d", task_id)
                         return False

--- a/osgbuild/kojiinter.py
+++ b/osgbuild/kojiinter.py
@@ -2,7 +2,12 @@
 # pylint: disable=W0614,C0103
 
 
-import ConfigParser
+from __future__ import absolute_import
+from __future__ import print_function
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 import logging
 import re
 import os
@@ -10,10 +15,10 @@ import time
 import urllib2
 from urllib2 import HTTPError
 
-from osgbuild.constants import *
-from osgbuild import clientcert
-from osgbuild import utils
-from osgbuild.error import KojiError, type_of_error
+from .constants import *
+from . import clientcert
+from . import utils
+from .error import KojiError, type_of_error
 
 log = logging.getLogger(__name__)
 
@@ -172,7 +177,7 @@ class KojiInter(object):
 
     def build_git(self, remote, rev, path):
         """Submit a GIT build"""
-        print remote
+        print(remote)
         return KojiInter.backend.build("git+" + remote + "?" + path + "#" + rev,
                                        self.target,
                                        self.scratch,
@@ -220,7 +225,7 @@ class KojiShellInter(object):
             if not self.dry_run:
                 utils.checked_call(cmd)
             else:
-                print " ".join(cmd)
+                print(" ".join(cmd))
 
     def get_build_and_dest_tags(self, target):
         """Return the build and destination tags for the current target."""
@@ -263,7 +268,7 @@ class KojiShellInter(object):
         if not self.dry_run:
             err = utils.unchecked_call(self.koji_cmd + build_subcmd)
         else:
-            print " ".join(self.koji_cmd + build_subcmd)
+            print(" ".join(self.koji_cmd + build_subcmd))
             err = 0
 
         if err:
@@ -277,7 +282,7 @@ class KojiShellInter(object):
             if not self.dry_run:
                 err2 = utils.unchecked_call(self.koji_cmd + regen_repo_subcmd)
             else:
-                print " ".join(self.koji_cmd + regen_repo_subcmd)
+                print(" ".join(self.koji_cmd + regen_repo_subcmd))
                 err2 = 0
             if err2:
                 raise KojiError("koji regen-repo failed with exit code " + str(err2))
@@ -321,7 +326,7 @@ class KojiShellInter(object):
             search_subcmd.append("--exact")
         search_subcmd.append(terms)
 
-        out, err = utils.sbacktick(self.koji_cmd + search_subcmd)       
+        out, err = utils.sbacktick(self.koji_cmd + search_subcmd)
         if err:
             raise KojiError("koji search failed with exit code " + str(err))
         return out.split("\n")
@@ -430,16 +435,16 @@ class KojiLibInter(object):
         if not config_file or not os.path.isfile(config_file):
             raise KojiError("Can't find koji config file.")
         try:
-            cfg = ConfigParser.ConfigParser()
+            cfg = configparser.ConfigParser()
             cfg.read(config_file)
             items = dict(cfg.items('koji'))
 
             # special case: use_old_ssl is a boolean so get ConfigParser to parse it
             try:
                 self.use_old_ssl = cfg.getboolean('koji', 'use_old_ssl')
-            except ConfigParser.NoOptionError:
+            except configparser.NoOptionError:
                 pass
-        except ConfigParser.Error as err:
+        except configparser.Error as err:
             raise KojiError("Can't read config file from %s: %s" % (config_file, str(err)))
         for var in ['ca', 'cert', 'server', 'serverca', 'weburl']:
             if items.get(var):
@@ -625,7 +630,7 @@ class KojiLibInter(object):
             # el5-osg-build and the arch is noarch, files will be in 'el5-osg-noarch'.
             task_info = session.getTaskInfo(task_id, request=True)
             if task_info.get('method', "") == 'buildArch':
-                if task_info.has_key('request'):
+                if 'request' in task_info:
                     tag_id, arch = task_info['request'][1:3]
                     tag_info = session.getTag(tag_id)
                     try:

--- a/osgbuild/kojiinter.py
+++ b/osgbuild/kojiinter.py
@@ -9,8 +9,10 @@ try:
 except ImportError:
     import ConfigParser as configparser
 import logging
+import random
 import re
 import os
+import string
 import sys
 import time
 try:
@@ -577,8 +579,18 @@ class KojiLibInter(object):
         return os.path.join(serverdir, os.path.basename(source))
 
 
+    # taken from cli/koji from Koji version 1.11
+    # Copyright (c) 2005-2014 Red Hat, Inc.
     def _unique_path(self, prefix="cli-build"):
-        return kojicli._unique_path(prefix)
+        """Create a unique path fragment by appending a path component
+        to prefix.  The path component will consist of a string of letter and numbers
+        that is unlikely to be a duplicate, but is not guaranteed to be unique."""
+        # Use time() in the dirname to provide a little more information when
+        # browsing the filesystem.
+        # For some reason repr(time.time()) includes 4 or 5
+        # more digits of precision than str(time.time())
+        return '%s/%r.%s' % (prefix, time.time(),
+                          ''.join([random.choice(string.ascii_letters) for i in range(8)]))
 
 
     def get_build_and_dest_tags(self, target):

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -17,6 +17,8 @@ Wishlist:
 # TODO Shouldn't need koji access for 'rpmbuild', but currently does since it
 # gets the values for the --repo arg -- which is only used for koji builds.
 # Make it so.
+from __future__ import absolute_import
+from __future__ import print_function
 import logging
 from optparse import OptionGroup, OptionParser, OptionValueError
 import re
@@ -24,20 +26,20 @@ import os
 import sys
 import tempfile
 
-from osgbuild.constants import *
-from osgbuild.error import UsageError, KojiError, SVNError, GitError, Error
-from osgbuild import srpm
-from osgbuild import svn
-from osgbuild import git
-from osgbuild import utils
+from .constants import *
+from .error import UsageError, KojiError, SVNError, GitError, Error
+from . import srpm
+from . import svn
+from . import git
+from . import utils
 
 try:
-    from osgbuild import kojiinter
+    from . import kojiinter
 except ImportError:
     kojiinter = None
 
 try:
-    from osgbuild import mock
+    from . import mock
 except ImportError:
     mock = None
 
@@ -83,8 +85,8 @@ def main(argv):
 
             vcs = (git_ok and git) or (svn_ok and svn)
             if not vcs:
-                print "VCS build requested but no usable VCS found for " + pkg
-                print "Exiting"
+                print("VCS build requested but no usable VCS found for " + pkg)
+                print("Exiting")
                 return 1
 
             if not buildopts['scratch']:
@@ -148,11 +150,11 @@ def main(argv):
                     method()
     # end of main loop
     # HACK
-    task_ids = filter(None, task_ids)
+    task_ids = [_f for _f in task_ids if _f]
     if kojiinter and kojiinter.KojiInter.backend and task_ids:
-        print "Koji task ids are:", task_ids
+        print("Koji task ids are:", task_ids)
         for tid in task_ids:
-            print KOJI_WEB + "/koji/taskinfo?taskID=" + str(tid)
+            print(KOJI_WEB + "/koji/taskinfo?taskID=" + str(tid))
         if not buildopts['no_wait']:
             ret = kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
             # TODO This is not implemented for the KojiShellInter backend
@@ -163,7 +165,7 @@ def main(argv):
                 elif not isinstance(kojiinter.KojiInter.backend, kojiinter.KojiLibInter):
                     log.warning("--getfiles is only implemented on the KojiLib backend")
                 else:
-                    for destdir, tids in task_ids_by_results_dir.iteritems():
+                    for destdir, tids in task_ids_by_results_dir.items():
                         if kojiinter.KojiInter.backend.download_results(tids, destdir):
                             log.info("Results and logs downloaded to %s", destdir)
             try:
@@ -370,7 +372,7 @@ rpmbuild     Build using rpmbuild(8) on the local machine
         help="Fully extract all source files")
     parser.add_option_group(prebuild_group)
 
-    rpmbuild_mock_group = OptionGroup(parser, 
+    rpmbuild_mock_group = OptionGroup(parser,
                                       "rpmbuild and mock task options")
     rpmbuild_mock_group.add_option(
         "--distro-tag",
@@ -722,13 +724,13 @@ def print_version_and_exit():
     if __version__ == '@' + 'VERSION' + '@':
         out, ret = utils.sbacktick("git -C %s describe --tags" % utils.shell_quote(os.path.dirname(os.path.realpath(sys.argv[0]))),
                                    err2out=False)
-        print "osg-build development version",
+        print("osg-build development version", end=' ')
         if not ret:
-            print " " + out
+            print(" " + out)
         else:
-            print
+            print()
     else:
-        print "osg-build " + __version__
+        print("osg-build " + __version__)
     sys.exit(0)
 
 

--- a/osgbuild/mock.py
+++ b/osgbuild/mock.py
@@ -1,5 +1,6 @@
 """mock wrapper class and functions for osg-build"""
 # pylint: disable=W0614
+from __future__ import absolute_import
 from fnmatch import fnmatch
 from glob import glob
 import atexit
@@ -10,9 +11,9 @@ import shutil
 import string
 import tempfile
 
-from osgbuild.constants import *
-from osgbuild.error import MockError, OSGBuildError
-from osgbuild import utils
+from .constants import *
+from .error import MockError, OSGBuildError
+from . import utils
 
 
 

--- a/osgbuild/six.py
+++ b/osgbuild/six.py
@@ -1,0 +1,868 @@
+"""Utilities for writing code that runs on Python 2 and 3"""
+
+# Copyright (c) 2010-2015 Benjamin Peterson
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import absolute_import
+
+import functools
+import itertools
+import operator
+import sys
+import types
+
+__author__ = "Benjamin Peterson <benjamin@python.org>"
+__version__ = "1.10.0"
+
+
+# Useful for very coarse version differentiation.
+PY2 = sys.version_info[0] == 2
+PY3 = sys.version_info[0] == 3
+PY34 = sys.version_info[0:2] >= (3, 4)
+
+if PY3:
+    string_types = str,
+    integer_types = int,
+    class_types = type,
+    text_type = str
+    binary_type = bytes
+
+    MAXSIZE = sys.maxsize
+else:
+    string_types = basestring,
+    integer_types = (int, long)
+    class_types = (type, types.ClassType)
+    text_type = unicode
+    binary_type = str
+
+    if sys.platform.startswith("java"):
+        # Jython always uses 32 bits.
+        MAXSIZE = int((1 << 31) - 1)
+    else:
+        # It's possible to have sizeof(long) != sizeof(Py_ssize_t).
+        class X(object):
+
+            def __len__(self):
+                return 1 << 31
+        try:
+            len(X())
+        except OverflowError:
+            # 32-bit
+            MAXSIZE = int((1 << 31) - 1)
+        else:
+            # 64-bit
+            MAXSIZE = int((1 << 63) - 1)
+        del X
+
+
+def _add_doc(func, doc):
+    """Add documentation to a function."""
+    func.__doc__ = doc
+
+
+def _import_module(name):
+    """Import module, returning the module after the last dot."""
+    __import__(name)
+    return sys.modules[name]
+
+
+class _LazyDescr(object):
+
+    def __init__(self, name):
+        self.name = name
+
+    def __get__(self, obj, tp):
+        result = self._resolve()
+        setattr(obj, self.name, result)  # Invokes __set__.
+        try:
+            # This is a bit ugly, but it avoids running this again by
+            # removing this descriptor.
+            delattr(obj.__class__, self.name)
+        except AttributeError:
+            pass
+        return result
+
+
+class MovedModule(_LazyDescr):
+
+    def __init__(self, name, old, new=None):
+        super(MovedModule, self).__init__(name)
+        if PY3:
+            if new is None:
+                new = name
+            self.mod = new
+        else:
+            self.mod = old
+
+    def _resolve(self):
+        return _import_module(self.mod)
+
+    def __getattr__(self, attr):
+        _module = self._resolve()
+        value = getattr(_module, attr)
+        setattr(self, attr, value)
+        return value
+
+
+class _LazyModule(types.ModuleType):
+
+    def __init__(self, name):
+        super(_LazyModule, self).__init__(name)
+        self.__doc__ = self.__class__.__doc__
+
+    def __dir__(self):
+        attrs = ["__doc__", "__name__"]
+        attrs += [attr.name for attr in self._moved_attributes]
+        return attrs
+
+    # Subclasses should override this
+    _moved_attributes = []
+
+
+class MovedAttribute(_LazyDescr):
+
+    def __init__(self, name, old_mod, new_mod, old_attr=None, new_attr=None):
+        super(MovedAttribute, self).__init__(name)
+        if PY3:
+            if new_mod is None:
+                new_mod = name
+            self.mod = new_mod
+            if new_attr is None:
+                if old_attr is None:
+                    new_attr = name
+                else:
+                    new_attr = old_attr
+            self.attr = new_attr
+        else:
+            self.mod = old_mod
+            if old_attr is None:
+                old_attr = name
+            self.attr = old_attr
+
+    def _resolve(self):
+        module = _import_module(self.mod)
+        return getattr(module, self.attr)
+
+
+class _SixMetaPathImporter(object):
+
+    """
+    A meta path importer to import six.moves and its submodules.
+
+    This class implements a PEP302 finder and loader. It should be compatible
+    with Python 2.5 and all existing versions of Python3
+    """
+
+    def __init__(self, six_module_name):
+        self.name = six_module_name
+        self.known_modules = {}
+
+    def _add_module(self, mod, *fullnames):
+        for fullname in fullnames:
+            self.known_modules[self.name + "." + fullname] = mod
+
+    def _get_module(self, fullname):
+        return self.known_modules[self.name + "." + fullname]
+
+    def find_module(self, fullname, path=None):
+        if fullname in self.known_modules:
+            return self
+        return None
+
+    def __get_module(self, fullname):
+        try:
+            return self.known_modules[fullname]
+        except KeyError:
+            raise ImportError("This loader does not know module " + fullname)
+
+    def load_module(self, fullname):
+        try:
+            # in case of a reload
+            return sys.modules[fullname]
+        except KeyError:
+            pass
+        mod = self.__get_module(fullname)
+        if isinstance(mod, MovedModule):
+            mod = mod._resolve()
+        else:
+            mod.__loader__ = self
+        sys.modules[fullname] = mod
+        return mod
+
+    def is_package(self, fullname):
+        """
+        Return true, if the named module is a package.
+
+        We need this method to get correct spec objects with
+        Python 3.4 (see PEP451)
+        """
+        return hasattr(self.__get_module(fullname), "__path__")
+
+    def get_code(self, fullname):
+        """Return None
+
+        Required, if is_package is implemented"""
+        self.__get_module(fullname)  # eventually raises ImportError
+        return None
+    get_source = get_code  # same as get_code
+
+_importer = _SixMetaPathImporter(__name__)
+
+
+class _MovedItems(_LazyModule):
+
+    """Lazy loading of moved objects"""
+    __path__ = []  # mark as package
+
+
+_moved_attributes = [
+    MovedAttribute("cStringIO", "cStringIO", "io", "StringIO"),
+    MovedAttribute("filter", "itertools", "builtins", "ifilter", "filter"),
+    MovedAttribute("filterfalse", "itertools", "itertools", "ifilterfalse", "filterfalse"),
+    MovedAttribute("input", "__builtin__", "builtins", "raw_input", "input"),
+    MovedAttribute("intern", "__builtin__", "sys"),
+    MovedAttribute("map", "itertools", "builtins", "imap", "map"),
+    MovedAttribute("getcwd", "os", "os", "getcwdu", "getcwd"),
+    MovedAttribute("getcwdb", "os", "os", "getcwd", "getcwdb"),
+    MovedAttribute("range", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("reload_module", "__builtin__", "importlib" if PY34 else "imp", "reload"),
+    MovedAttribute("reduce", "__builtin__", "functools"),
+    MovedAttribute("shlex_quote", "pipes", "shlex", "quote"),
+    MovedAttribute("StringIO", "StringIO", "io"),
+    MovedAttribute("UserDict", "UserDict", "collections"),
+    MovedAttribute("UserList", "UserList", "collections"),
+    MovedAttribute("UserString", "UserString", "collections"),
+    MovedAttribute("xrange", "__builtin__", "builtins", "xrange", "range"),
+    MovedAttribute("zip", "itertools", "builtins", "izip", "zip"),
+    MovedAttribute("zip_longest", "itertools", "itertools", "izip_longest", "zip_longest"),
+    MovedModule("builtins", "__builtin__"),
+    MovedModule("configparser", "ConfigParser"),
+    MovedModule("copyreg", "copy_reg"),
+    MovedModule("dbm_gnu", "gdbm", "dbm.gnu"),
+    MovedModule("_dummy_thread", "dummy_thread", "_dummy_thread"),
+    MovedModule("http_cookiejar", "cookielib", "http.cookiejar"),
+    MovedModule("http_cookies", "Cookie", "http.cookies"),
+    MovedModule("html_entities", "htmlentitydefs", "html.entities"),
+    MovedModule("html_parser", "HTMLParser", "html.parser"),
+    MovedModule("http_client", "httplib", "http.client"),
+    MovedModule("email_mime_multipart", "email.MIMEMultipart", "email.mime.multipart"),
+    MovedModule("email_mime_nonmultipart", "email.MIMENonMultipart", "email.mime.nonmultipart"),
+    MovedModule("email_mime_text", "email.MIMEText", "email.mime.text"),
+    MovedModule("email_mime_base", "email.MIMEBase", "email.mime.base"),
+    MovedModule("BaseHTTPServer", "BaseHTTPServer", "http.server"),
+    MovedModule("CGIHTTPServer", "CGIHTTPServer", "http.server"),
+    MovedModule("SimpleHTTPServer", "SimpleHTTPServer", "http.server"),
+    MovedModule("cPickle", "cPickle", "pickle"),
+    MovedModule("queue", "Queue"),
+    MovedModule("reprlib", "repr"),
+    MovedModule("socketserver", "SocketServer"),
+    MovedModule("_thread", "thread", "_thread"),
+    MovedModule("tkinter", "Tkinter"),
+    MovedModule("tkinter_dialog", "Dialog", "tkinter.dialog"),
+    MovedModule("tkinter_filedialog", "FileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_scrolledtext", "ScrolledText", "tkinter.scrolledtext"),
+    MovedModule("tkinter_simpledialog", "SimpleDialog", "tkinter.simpledialog"),
+    MovedModule("tkinter_tix", "Tix", "tkinter.tix"),
+    MovedModule("tkinter_ttk", "ttk", "tkinter.ttk"),
+    MovedModule("tkinter_constants", "Tkconstants", "tkinter.constants"),
+    MovedModule("tkinter_dnd", "Tkdnd", "tkinter.dnd"),
+    MovedModule("tkinter_colorchooser", "tkColorChooser",
+                "tkinter.colorchooser"),
+    MovedModule("tkinter_commondialog", "tkCommonDialog",
+                "tkinter.commondialog"),
+    MovedModule("tkinter_tkfiledialog", "tkFileDialog", "tkinter.filedialog"),
+    MovedModule("tkinter_font", "tkFont", "tkinter.font"),
+    MovedModule("tkinter_messagebox", "tkMessageBox", "tkinter.messagebox"),
+    MovedModule("tkinter_tksimpledialog", "tkSimpleDialog",
+                "tkinter.simpledialog"),
+    MovedModule("urllib_parse", __name__ + ".moves.urllib_parse", "urllib.parse"),
+    MovedModule("urllib_error", __name__ + ".moves.urllib_error", "urllib.error"),
+    MovedModule("urllib", __name__ + ".moves.urllib", __name__ + ".moves.urllib"),
+    MovedModule("urllib_robotparser", "robotparser", "urllib.robotparser"),
+    MovedModule("xmlrpc_client", "xmlrpclib", "xmlrpc.client"),
+    MovedModule("xmlrpc_server", "SimpleXMLRPCServer", "xmlrpc.server"),
+]
+# Add windows specific modules.
+if sys.platform == "win32":
+    _moved_attributes += [
+        MovedModule("winreg", "_winreg"),
+    ]
+
+for attr in _moved_attributes:
+    setattr(_MovedItems, attr.name, attr)
+    if isinstance(attr, MovedModule):
+        _importer._add_module(attr, "moves." + attr.name)
+del attr
+
+_MovedItems._moved_attributes = _moved_attributes
+
+moves = _MovedItems(__name__ + ".moves")
+_importer._add_module(moves, "moves")
+
+
+class Module_six_moves_urllib_parse(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_parse"""
+
+
+_urllib_parse_moved_attributes = [
+    MovedAttribute("ParseResult", "urlparse", "urllib.parse"),
+    MovedAttribute("SplitResult", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qs", "urlparse", "urllib.parse"),
+    MovedAttribute("parse_qsl", "urlparse", "urllib.parse"),
+    MovedAttribute("urldefrag", "urlparse", "urllib.parse"),
+    MovedAttribute("urljoin", "urlparse", "urllib.parse"),
+    MovedAttribute("urlparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunparse", "urlparse", "urllib.parse"),
+    MovedAttribute("urlunsplit", "urlparse", "urllib.parse"),
+    MovedAttribute("quote", "urllib", "urllib.parse"),
+    MovedAttribute("quote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("unquote", "urllib", "urllib.parse"),
+    MovedAttribute("unquote_plus", "urllib", "urllib.parse"),
+    MovedAttribute("urlencode", "urllib", "urllib.parse"),
+    MovedAttribute("splitquery", "urllib", "urllib.parse"),
+    MovedAttribute("splittag", "urllib", "urllib.parse"),
+    MovedAttribute("splituser", "urllib", "urllib.parse"),
+    MovedAttribute("uses_fragment", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_netloc", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_params", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_query", "urlparse", "urllib.parse"),
+    MovedAttribute("uses_relative", "urlparse", "urllib.parse"),
+]
+for attr in _urllib_parse_moved_attributes:
+    setattr(Module_six_moves_urllib_parse, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_parse._moved_attributes = _urllib_parse_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_parse(__name__ + ".moves.urllib_parse"),
+                      "moves.urllib_parse", "moves.urllib.parse")
+
+
+class Module_six_moves_urllib_error(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_error"""
+
+
+_urllib_error_moved_attributes = [
+    MovedAttribute("URLError", "urllib2", "urllib.error"),
+    MovedAttribute("HTTPError", "urllib2", "urllib.error"),
+    MovedAttribute("ContentTooShortError", "urllib", "urllib.error"),
+]
+for attr in _urllib_error_moved_attributes:
+    setattr(Module_six_moves_urllib_error, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_error._moved_attributes = _urllib_error_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_error(__name__ + ".moves.urllib.error"),
+                      "moves.urllib_error", "moves.urllib.error")
+
+
+class Module_six_moves_urllib_request(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_request"""
+
+
+_urllib_request_moved_attributes = [
+    MovedAttribute("urlopen", "urllib2", "urllib.request"),
+    MovedAttribute("install_opener", "urllib2", "urllib.request"),
+    MovedAttribute("build_opener", "urllib2", "urllib.request"),
+    MovedAttribute("pathname2url", "urllib", "urllib.request"),
+    MovedAttribute("url2pathname", "urllib", "urllib.request"),
+    MovedAttribute("getproxies", "urllib", "urllib.request"),
+    MovedAttribute("Request", "urllib2", "urllib.request"),
+    MovedAttribute("OpenerDirector", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDefaultErrorHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPRedirectHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPCookieProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyHandler", "urllib2", "urllib.request"),
+    MovedAttribute("BaseHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgr", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPPasswordMgrWithDefaultRealm", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyBasicAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("AbstractDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("ProxyDigestAuthHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPSHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FileHandler", "urllib2", "urllib.request"),
+    MovedAttribute("FTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("CacheFTPHandler", "urllib2", "urllib.request"),
+    MovedAttribute("UnknownHandler", "urllib2", "urllib.request"),
+    MovedAttribute("HTTPErrorProcessor", "urllib2", "urllib.request"),
+    MovedAttribute("urlretrieve", "urllib", "urllib.request"),
+    MovedAttribute("urlcleanup", "urllib", "urllib.request"),
+    MovedAttribute("URLopener", "urllib", "urllib.request"),
+    MovedAttribute("FancyURLopener", "urllib", "urllib.request"),
+    MovedAttribute("proxy_bypass", "urllib", "urllib.request"),
+]
+for attr in _urllib_request_moved_attributes:
+    setattr(Module_six_moves_urllib_request, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_request._moved_attributes = _urllib_request_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_request(__name__ + ".moves.urllib.request"),
+                      "moves.urllib_request", "moves.urllib.request")
+
+
+class Module_six_moves_urllib_response(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_response"""
+
+
+_urllib_response_moved_attributes = [
+    MovedAttribute("addbase", "urllib", "urllib.response"),
+    MovedAttribute("addclosehook", "urllib", "urllib.response"),
+    MovedAttribute("addinfo", "urllib", "urllib.response"),
+    MovedAttribute("addinfourl", "urllib", "urllib.response"),
+]
+for attr in _urllib_response_moved_attributes:
+    setattr(Module_six_moves_urllib_response, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_response._moved_attributes = _urllib_response_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_response(__name__ + ".moves.urllib.response"),
+                      "moves.urllib_response", "moves.urllib.response")
+
+
+class Module_six_moves_urllib_robotparser(_LazyModule):
+
+    """Lazy loading of moved objects in six.moves.urllib_robotparser"""
+
+
+_urllib_robotparser_moved_attributes = [
+    MovedAttribute("RobotFileParser", "robotparser", "urllib.robotparser"),
+]
+for attr in _urllib_robotparser_moved_attributes:
+    setattr(Module_six_moves_urllib_robotparser, attr.name, attr)
+del attr
+
+Module_six_moves_urllib_robotparser._moved_attributes = _urllib_robotparser_moved_attributes
+
+_importer._add_module(Module_six_moves_urllib_robotparser(__name__ + ".moves.urllib.robotparser"),
+                      "moves.urllib_robotparser", "moves.urllib.robotparser")
+
+
+class Module_six_moves_urllib(types.ModuleType):
+
+    """Create a six.moves.urllib namespace that resembles the Python 3 namespace"""
+    __path__ = []  # mark as package
+    parse = _importer._get_module("moves.urllib_parse")
+    error = _importer._get_module("moves.urllib_error")
+    request = _importer._get_module("moves.urllib_request")
+    response = _importer._get_module("moves.urllib_response")
+    robotparser = _importer._get_module("moves.urllib_robotparser")
+
+    def __dir__(self):
+        return ['parse', 'error', 'request', 'response', 'robotparser']
+
+_importer._add_module(Module_six_moves_urllib(__name__ + ".moves.urllib"),
+                      "moves.urllib")
+
+
+def add_move(move):
+    """Add an item to six.moves."""
+    setattr(_MovedItems, move.name, move)
+
+
+def remove_move(name):
+    """Remove item from six.moves."""
+    try:
+        delattr(_MovedItems, name)
+    except AttributeError:
+        try:
+            del moves.__dict__[name]
+        except KeyError:
+            raise AttributeError("no such move, %r" % (name,))
+
+
+if PY3:
+    _meth_func = "__func__"
+    _meth_self = "__self__"
+
+    _func_closure = "__closure__"
+    _func_code = "__code__"
+    _func_defaults = "__defaults__"
+    _func_globals = "__globals__"
+else:
+    _meth_func = "im_func"
+    _meth_self = "im_self"
+
+    _func_closure = "func_closure"
+    _func_code = "func_code"
+    _func_defaults = "func_defaults"
+    _func_globals = "func_globals"
+
+
+try:
+    advance_iterator = next
+except NameError:
+    def advance_iterator(it):
+        return it.next()
+next = advance_iterator
+
+
+try:
+    callable = callable
+except NameError:
+    def callable(obj):
+        return any("__call__" in klass.__dict__ for klass in type(obj).__mro__)
+
+
+if PY3:
+    def get_unbound_function(unbound):
+        return unbound
+
+    create_bound_method = types.MethodType
+
+    def create_unbound_method(func, cls):
+        return func
+
+    Iterator = object
+else:
+    def get_unbound_function(unbound):
+        return unbound.im_func
+
+    def create_bound_method(func, obj):
+        return types.MethodType(func, obj, obj.__class__)
+
+    def create_unbound_method(func, cls):
+        return types.MethodType(func, None, cls)
+
+    class Iterator(object):
+
+        def next(self):
+            return type(self).__next__(self)
+
+    callable = callable
+_add_doc(get_unbound_function,
+         """Get the function out of a possibly unbound function""")
+
+
+get_method_function = operator.attrgetter(_meth_func)
+get_method_self = operator.attrgetter(_meth_self)
+get_function_closure = operator.attrgetter(_func_closure)
+get_function_code = operator.attrgetter(_func_code)
+get_function_defaults = operator.attrgetter(_func_defaults)
+get_function_globals = operator.attrgetter(_func_globals)
+
+
+if PY3:
+    def iterkeys(d, **kw):
+        return iter(d.keys(**kw))
+
+    def itervalues(d, **kw):
+        return iter(d.values(**kw))
+
+    def iteritems(d, **kw):
+        return iter(d.items(**kw))
+
+    def iterlists(d, **kw):
+        return iter(d.lists(**kw))
+
+    viewkeys = operator.methodcaller("keys")
+
+    viewvalues = operator.methodcaller("values")
+
+    viewitems = operator.methodcaller("items")
+else:
+    def iterkeys(d, **kw):
+        return d.iterkeys(**kw)
+
+    def itervalues(d, **kw):
+        return d.itervalues(**kw)
+
+    def iteritems(d, **kw):
+        return d.iteritems(**kw)
+
+    def iterlists(d, **kw):
+        return d.iterlists(**kw)
+
+    viewkeys = operator.methodcaller("viewkeys")
+
+    viewvalues = operator.methodcaller("viewvalues")
+
+    viewitems = operator.methodcaller("viewitems")
+
+_add_doc(iterkeys, "Return an iterator over the keys of a dictionary.")
+_add_doc(itervalues, "Return an iterator over the values of a dictionary.")
+_add_doc(iteritems,
+         "Return an iterator over the (key, value) pairs of a dictionary.")
+_add_doc(iterlists,
+         "Return an iterator over the (key, [values]) pairs of a dictionary.")
+
+
+if PY3:
+    def b(s):
+        return s.encode("latin-1")
+
+    def u(s):
+        return s
+    unichr = chr
+    import struct
+    int2byte = struct.Struct(">B").pack
+    del struct
+    byte2int = operator.itemgetter(0)
+    indexbytes = operator.getitem
+    iterbytes = iter
+    import io
+    StringIO = io.StringIO
+    BytesIO = io.BytesIO
+    _assertCountEqual = "assertCountEqual"
+    if sys.version_info[1] <= 1:
+        _assertRaisesRegex = "assertRaisesRegexp"
+        _assertRegex = "assertRegexpMatches"
+    else:
+        _assertRaisesRegex = "assertRaisesRegex"
+        _assertRegex = "assertRegex"
+else:
+    def b(s):
+        return s
+    # Workaround for standalone backslash
+
+    def u(s):
+        return unicode(s.replace(r'\\', r'\\\\'), "unicode_escape")
+    unichr = unichr
+    int2byte = chr
+
+    def byte2int(bs):
+        return ord(bs[0])
+
+    def indexbytes(buf, i):
+        return ord(buf[i])
+    iterbytes = functools.partial(itertools.imap, ord)
+    import StringIO
+    StringIO = BytesIO = StringIO.StringIO
+    _assertCountEqual = "assertItemsEqual"
+    _assertRaisesRegex = "assertRaisesRegexp"
+    _assertRegex = "assertRegexpMatches"
+_add_doc(b, """Byte literal""")
+_add_doc(u, """Text literal""")
+
+
+def assertCountEqual(self, *args, **kwargs):
+    return getattr(self, _assertCountEqual)(*args, **kwargs)
+
+
+def assertRaisesRegex(self, *args, **kwargs):
+    return getattr(self, _assertRaisesRegex)(*args, **kwargs)
+
+
+def assertRegex(self, *args, **kwargs):
+    return getattr(self, _assertRegex)(*args, **kwargs)
+
+
+if PY3:
+    exec_ = getattr(moves.builtins, "exec")
+
+    def reraise(tp, value, tb=None):
+        if value is None:
+            value = tp()
+        if value.__traceback__ is not tb:
+            raise value.with_traceback(tb)
+        raise value
+
+else:
+    def exec_(_code_, _globs_=None, _locs_=None):
+        """Execute code in a namespace."""
+        if _globs_ is None:
+            frame = sys._getframe(1)
+            _globs_ = frame.f_globals
+            if _locs_ is None:
+                _locs_ = frame.f_locals
+            del frame
+        elif _locs_ is None:
+            _locs_ = _globs_
+        exec("""exec _code_ in _globs_, _locs_""")
+
+    exec_("""def reraise(tp, value, tb=None):
+    raise tp, value, tb
+""")
+
+
+if sys.version_info[:2] == (3, 2):
+    exec_("""def raise_from(value, from_value):
+    if from_value is None:
+        raise value
+    raise value from from_value
+""")
+elif sys.version_info[:2] > (3, 2):
+    exec_("""def raise_from(value, from_value):
+    raise value from from_value
+""")
+else:
+    def raise_from(value, from_value):
+        raise value
+
+
+print_ = getattr(moves.builtins, "print", None)
+if print_ is None:
+    def print_(*args, **kwargs):
+        """The new-style print function for Python 2.4 and 2.5."""
+        fp = kwargs.pop("file", sys.stdout)
+        if fp is None:
+            return
+
+        def write(data):
+            if not isinstance(data, basestring):
+                data = str(data)
+            # If the file has an encoding, encode unicode with it.
+            if (isinstance(fp, file) and
+                    isinstance(data, unicode) and
+                    fp.encoding is not None):
+                errors = getattr(fp, "errors", None)
+                if errors is None:
+                    errors = "strict"
+                data = data.encode(fp.encoding, errors)
+            fp.write(data)
+        want_unicode = False
+        sep = kwargs.pop("sep", None)
+        if sep is not None:
+            if isinstance(sep, unicode):
+                want_unicode = True
+            elif not isinstance(sep, str):
+                raise TypeError("sep must be None or a string")
+        end = kwargs.pop("end", None)
+        if end is not None:
+            if isinstance(end, unicode):
+                want_unicode = True
+            elif not isinstance(end, str):
+                raise TypeError("end must be None or a string")
+        if kwargs:
+            raise TypeError("invalid keyword arguments to print()")
+        if not want_unicode:
+            for arg in args:
+                if isinstance(arg, unicode):
+                    want_unicode = True
+                    break
+        if want_unicode:
+            newline = unicode("\n")
+            space = unicode(" ")
+        else:
+            newline = "\n"
+            space = " "
+        if sep is None:
+            sep = space
+        if end is None:
+            end = newline
+        for i, arg in enumerate(args):
+            if i:
+                write(sep)
+            write(arg)
+        write(end)
+if sys.version_info[:2] < (3, 3):
+    _print = print_
+
+    def print_(*args, **kwargs):
+        fp = kwargs.get("file", sys.stdout)
+        flush = kwargs.pop("flush", False)
+        _print(*args, **kwargs)
+        if flush and fp is not None:
+            fp.flush()
+
+_add_doc(reraise, """Reraise an exception.""")
+
+if sys.version_info[0:2] < (3, 4):
+    def wraps(wrapped, assigned=functools.WRAPPER_ASSIGNMENTS,
+              updated=functools.WRAPPER_UPDATES):
+        def wrapper(f):
+            f = functools.wraps(wrapped, assigned, updated)(f)
+            f.__wrapped__ = wrapped
+            return f
+        return wrapper
+else:
+    wraps = functools.wraps
+
+
+def with_metaclass(meta, *bases):
+    """Create a base class with a metaclass."""
+    # This requires a bit of explanation: the basic idea is to make a dummy
+    # metaclass for one level of class instantiation that replaces itself with
+    # the actual metaclass.
+    class metaclass(meta):
+
+        def __new__(cls, name, this_bases, d):
+            return meta(name, bases, d)
+    return type.__new__(metaclass, 'temporary_class', (), {})
+
+
+def add_metaclass(metaclass):
+    """Class decorator for creating a class with a metaclass."""
+    def wrapper(cls):
+        orig_vars = cls.__dict__.copy()
+        slots = orig_vars.get('__slots__')
+        if slots is not None:
+            if isinstance(slots, str):
+                slots = [slots]
+            for slots_var in slots:
+                orig_vars.pop(slots_var)
+        orig_vars.pop('__dict__', None)
+        orig_vars.pop('__weakref__', None)
+        return metaclass(cls.__name__, cls.__bases__, orig_vars)
+    return wrapper
+
+
+def python_2_unicode_compatible(klass):
+    """
+    A decorator that defines __unicode__ and __str__ methods under Python 2.
+    Under Python 3 it does nothing.
+
+    To support Python 2 and 3 with a single code base, define a __str__ method
+    returning text and apply this decorator to the class.
+    """
+    if PY2:
+        if '__str__' not in klass.__dict__:
+            raise ValueError("@python_2_unicode_compatible cannot be applied "
+                             "to %s because it doesn't define __str__()." %
+                             klass.__name__)
+        klass.__unicode__ = klass.__str__
+        klass.__str__ = lambda self: self.__unicode__().encode('utf-8')
+    return klass
+
+
+# Complete the moves implementation.
+# This code is at the end of this module to speed up module loading.
+# Turn this module into a package.
+__path__ = []  # required for PEP 302 and PEP 451
+__package__ = __name__  # see PEP 366 @ReservedAssignment
+if globals().get("__spec__") is not None:
+    __spec__.submodule_search_locations = []  # PEP 451 @UndefinedVariable
+# Remove other six meta path importers, since they cause problems. This can
+# happen if six is removed from sys.modules and then reloaded. (Setuptools does
+# this for some reason.)
+if sys.meta_path:
+    for i, importer in enumerate(sys.meta_path):
+        # Here's some real nastiness: Another "instance" of the six module might
+        # be floating around. Therefore, we can't use isinstance() to check for
+        # the six meta path importer, since the other six instance will have
+        # inserted an importer with different class.
+        if (type(importer).__name__ == "_SixMetaPathImporter" and
+                importer.name == __name__):
+            del sys.meta_path[i]
+            break
+    del i, importer
+# Finally, add the importer to the meta path import hook.
+sys.meta_path.append(_importer)

--- a/osgbuild/srpm.py
+++ b/osgbuild/srpm.py
@@ -1,6 +1,8 @@
 """Tasks for an SRPM build."""
 
 # pylint: disable=W0614
+from __future__ import absolute_import
+from __future__ import print_function
 import glob
 import fnmatch
 import logging
@@ -9,10 +11,10 @@ import re
 import shutil
 
 # local
-from osgbuild.constants import *
-from osgbuild import fetch_sources
-from osgbuild import utils
-from osgbuild.error import *
+from .constants import *
+from . import fetch_sources
+from . import utils
+from .error import *
 
 
 log = logging.getLogger(__name__)
@@ -291,17 +293,17 @@ class SRPMBuild(object):
         lint_output, lint_returncode = utils.sbacktick(
             ["rpmlint", "-f", conf_file, srpm])
 
-        print lint_output
+        print(lint_output)
         if lint_returncode == 0:
-            print "rpmlint ok for " + self.package_name
+            print("rpmlint ok for " + self.package_name)
         elif lint_returncode < 64:
-            print "Error running rpmlint for " + self.package_name
+            print("Error running rpmlint for " + self.package_name)
         elif lint_returncode == 64:
-            print "rpmlint found problems with " + self.package_name
+            print("rpmlint found problems with " + self.package_name)
         elif lint_returncode == 66:
-            print "rpmlint found many problems with " + self.package_name
+            print("rpmlint found many problems with " + self.package_name)
         else:
-            print "unrecognized return code from rpmlint: " + str(lint_returncode)
+            print("unrecognized return code from rpmlint: " + str(lint_returncode))
 # end of SRPMBuild
 
 

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -1,11 +1,13 @@
 """Helper functions for an SVN build."""
+from __future__ import absolute_import
+from __future__ import print_function
 import re
 import os
 import errno
 
-from osgbuild.constants import SVN_ROOT, SVN_REDHAT_PATH, SVN_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
-from osgbuild.error import Error, SVNError, UsageError
-from osgbuild import utils
+from .constants import SVN_ROOT, SVN_REDHAT_PATH, SVN_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
+from .error import Error, SVNError, UsageError
+from . import utils
 
 
 def is_svn(package_dir):
@@ -44,8 +46,8 @@ def is_uncommitted(package_dir):
     if err:
         raise SVNError("Exit code %d getting SVN status. Output:\n%s" % (err, out))
     if out:
-        print "The following uncommitted changes exist:"
-        print out
+        print("The following uncommitted changes exist:")
+        print(out)
         return True
     else:
         return False
@@ -70,8 +72,8 @@ def is_outdated(package_dir):
         if outdated_flag == "*":
             outdated_files.append(line)
     if outdated_files:
-        print "The following outdated files exist:"
-        print "\n".join(outdated_files)
+        print("The following outdated files exist:")
+        print("\n".join(outdated_files))
         return True
     else:
         return False
@@ -160,9 +162,9 @@ def restricted_branch_matches_target(branch, target):
     are True.
 
     """
-    for (branch_pattern, branch_name) in SVN_RESTRICTED_BRANCHES.iteritems():
+    for (branch_pattern, branch_name) in SVN_RESTRICTED_BRANCHES.items():
         branch_match = re.search(branch_pattern, branch)
-        for (target_pattern, target_name) in KOJI_RESTRICTED_TARGETS.iteritems():
+        for (target_pattern, target_name) in KOJI_RESTRICTED_TARGETS.items():
             target_match = re.search(target_pattern, target)
 
             if branch_match and target_match and branch_name == target_name:

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -85,7 +85,7 @@ class XTestCase(unittest.TestCase):
     # Code from unittest in Python 2.7 (c) Python Software Foundation
     def assertRegexpMatches(self, text, regexp, msg=None):
         """Fail if 'text' does not match 'regexp'"""
-        if isinstance(regexp, basestring):
+        if isinstance(regexp, str):
             regexp = re.compile(regexp)
         if not regexp.search(text):
             msg = msg or "Regexp didn't match"
@@ -95,7 +95,7 @@ class XTestCase(unittest.TestCase):
     # Code from unittest in Python 2.7 (c) Python Software Foundation
     def assertNotRegexpMatches(self, text, regexp, msg=None):
         """Fail if 'text' matches 'regex'"""
-        if isinstance(regexp, basestring):
+        if isinstance(regexp, str):
             regexp = re.compile(regexp)
         match = regexp.search(text)
         if match:

--- a/osgbuild/test/test_osgpromote.py
+++ b/osgbuild/test/test_osgpromote.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 import sys
 sys.path.insert(0, '.')
 

--- a/osgbuild/utils.py
+++ b/osgbuild/utils.py
@@ -1,4 +1,6 @@
 """utilities for osg-build"""
+from __future__ import absolute_import
+from __future__ import print_function
 import errno
 import itertools
 import logging
@@ -10,6 +12,12 @@ import subprocess
 import sys
 import tempfile
 from datetime import datetime
+
+# python 3:
+try:
+    input_ = raw_input
+except NameError:
+    input_ = input
 
 
 log = logging.getLogger(__name__)
@@ -159,7 +167,7 @@ def unslurp(filename, contents):
     with open(filename, 'w') as fh:
         fh.write(contents)
 
-def atomic_unslurp(filename, contents, mode=0644):
+def atomic_unslurp(filename, contents, mode=0o644):
     """Write contents to a file, making sure a half-written file is never
     left behind in case of error.
 
@@ -231,7 +239,7 @@ def super_unpack(*compressed_files):
                 break
 
 
-def safe_makedirs(directory, mode=0777):
+def safe_makedirs(directory, mode=0o777):
     """Create a directory and all its parent directories, unless it already
     exists.
 
@@ -246,8 +254,8 @@ def ask(question, choices):
     user_choice = ""
     match = False
     while not match:
-        print question
-        user_choice = raw_input("[" + "/".join(choices) + "] ? ").strip().lower()
+        print(question)
+        user_choice = input_("[" + "/".join(choices) + "] ? ").strip().lower()
         for choice in choices_lc:
             if user_choice.startswith(choice):
                 match = True

--- a/osgbuild/utils.py
+++ b/osgbuild/utils.py
@@ -27,11 +27,11 @@ log = logging.getLogger(__name__)
 def to_str(strlike):
     if six.PY3:
         if isinstance(strlike, bytes):
-            return strlike.decode('utf-8', 'replace')
+            return strlike.decode('utf-8', 'ignore')
         else:
             return strlike
     else:
-        return strlike.encode('utf-8', 'replace')
+        return strlike.encode('utf-8', 'ignore')
 
 
 class CalledProcessError(Exception):

--- a/osgbuild/utils.py
+++ b/osgbuild/utils.py
@@ -31,7 +31,10 @@ def to_str(strlike):
         else:
             return strlike
     else:
-        return strlike.encode('utf-8', 'ignore')
+        if isinstance(strlike, unicode):
+            return strlike.encode('utf-8', 'ignore')
+        else:
+            return strlike
 
 
 class CalledProcessError(Exception):


### PR DESCRIPTION
Add support for running osg-build and other tools using Python 3. This is more future-proofing than anything that's useful right now -- for one, RHEL 6/7 do not include Python 3 versions of yum/rpm libraries.

I've been using this for the past month or two with Python 2 so there are likely no regressions; I also tested the code on Fedora 26/27 and it works fine there, other than problems with the Koji libraries themselves (our password caching and proxy cert patches don't work on the Python 3 version of Koji).