### PR TITLE
type=github support for .source files

### DIFF
--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -59,7 +59,7 @@ def process_meta_url(line, destdir):
         if not git_url:
             raise Error("No git URL provided: %s" % line)
         if not name:
-            basename = os.path.split(git_url)[-1]
+            basename = os.path.basename(git_url)
             if basename[-4:] == '.git':
                 name = basename[:-4]
             else:

--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -30,25 +30,44 @@ def process_meta_url(line, destdir):
     Process a serialized URL spec.  Should be of the format:
      type=git url=https://github.com/opensciencegrid/cvmfs-config-osg.git name=cvmfs-config-osg tag=0.1 hash=e2b54cd1b94c9e3eaee079490c9d85f193c52249
     'name' can be derived from the URL if the last component in the URL is of the form 'NAME.git'
+    OR
+     type=github repo=opensciencegrid/cvmfs-config-osg tag=0.1 hash=e2b54cd1b94c9e3eaee079490c9d85f193c52249
+    'name' can be taken from the repo if not specified.
     """
     contents = {}
     for entry in line.split():
         info = entry.split("=", 1)
         if len(info) > 1:
             contents[info[0].strip()] = info[1].strip()
-    tag_type = contents.get("type", "")
-    if tag_type != "git":
-        raise Error("Only 'git'-type URLs are understood: %s" % line)
-    git_url = contents.get('url')
-    if not git_url:
-        raise Error("No git URL provided: %s" % line)
+
     name = contents.get("name")
-    if not name:
-        basename = os.path.split(git_url)[-1]
-        if basename[-4:] == '.git':
-            name = basename[:-4]
-        else:
-            raise Error("No package name specified: %s" % line)
+    tag_type = contents.get("type", "")
+    if tag_type == "github":
+        repo = contents.get("repo")
+        if not repo:
+            raise Error("No repo specified: %s" % line)
+        m = re.match(r"([^\s/]+)/([^\s/]+?)(?:.git)?$", repo)
+        if not m:
+            raise Error("Repo syntax must be owner/project: %s" % line)
+        owner, project = m.group(1, 2)
+        git_url = "https://github.com/%s/%s" % (owner, project)
+        if not name:
+            name = project
+
+    elif tag_type == "git":
+        git_url = contents.get('url')
+        if not git_url:
+            raise Error("No git URL provided: %s" % line)
+        if not name:
+            basename = os.path.split(git_url)[-1]
+            if basename[-4:] == '.git':
+                name = basename[:-4]
+            else:
+                raise Error("No package name specified: %s" % line)
+
+    else:
+        raise Error("Only 'git'- and 'github'-type sources are understood: %s" % line)
+
     log.info("Checking out git repo for %s.", name)
     tag = contents.get("tag")
     if not tag:

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -279,7 +279,7 @@ class TestFetch(XTestCase):
             r"Patch0:\s+multilib-python.patch",
             "Spec file not overridden")
 
-    def test_github_fetch(self):
+    def test_git_fetch(self):
         common_setUp("native/redhat/branches/matyas/osg-build", "{2017-04-26}")
         checked_call(["python", "-m", "osgbuild.fetch_sources", "osg-build"])
         contents = get_listing('osg-build')
@@ -291,7 +291,7 @@ class TestFetch(XTestCase):
             "osg-build-1.8.90.tar.gz" in contents,
             "source tarball not found")
 
-    def test_github_fetch_spec(self):
+    def test_git_fetch_spec(self):
         common_setUp(opj(TRUNK, "osg-build"), "{2018-01-24}")
         checked_call(["python", "-m", "osgbuild.fetch_sources", "osg-build"])
         contents = get_listing('osg-build')
@@ -303,11 +303,22 @@ class TestFetch(XTestCase):
             "osg-build-1.11.1.tar.gz" in contents,
             "source tarball not found")
 
-    def test_github_fetch_spec_with_release(self):
+    def test_git_fetch_spec_with_release(self):
         go_to_temp_dir()
         os.mkdir("upstream")
         unslurp("upstream/github.source",
                 "type=git url=https://github.com/opensciencegrid/cvmfs-config-osg.git tag=v2.1-2 hash=5ea1914b621cef204879ec1cc55e0216e3812785")
+        checked_call(["python", "-m", "osgbuild.fetch_sources", "."])
+        contents = get_listing(".")
+
+        self.assertFalse("cvmfs-config-osg-2.1-2.tar.gz" in contents, "source tarball has incorrect name")
+        self.assertTrue("cvmfs-config-osg-2.1.tar.gz" in contents, "source tarball not found")
+
+    def test_github_fetch_spec_with_release(self):
+        go_to_temp_dir()
+        os.mkdir("upstream")
+        unslurp("upstream/github.source",
+                "type=github repo=opensciencegrid/cvmfs-config-osg tag=v2.1-2 hash=5ea1914b621cef204879ec1cc55e0216e3812785")
         checked_call(["python", "-m", "osgbuild.fetch_sources", "."])
         contents = get_listing(".")
 

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -280,10 +280,9 @@ class TestFetch(XTestCase):
             "Spec file not overridden")
 
     def test_github_fetch(self):
-        go_to_temp_dir()
-        svn_export('native/redhat/branches/matyas/osg-build', '{2017-04-26}', 'osg-build1')
-        checked_call(["python", "-m", "osgbuild.fetch_sources", "osg-build1"])
-        contents = get_listing('osg-build1')
+        common_setUp("native/redhat/branches/matyas/osg-build", "{2017-04-26}")
+        checked_call(["python", "-m", "osgbuild.fetch_sources", "osg-build"])
+        contents = get_listing('osg-build')
 
         self.assertTrue(
             "osg-build.spec" in contents,
@@ -293,10 +292,9 @@ class TestFetch(XTestCase):
             "source tarball not found")
 
     def test_github_fetch_spec(self):
-        go_to_temp_dir()
-        svn_export('native/redhat/trunk/osg-build', '{2018-01-24}', 'osg-build2')
-        checked_call(["python", "-m", "osgbuild.fetch_sources", "osg-build2"])
-        contents = get_listing('osg-build2')
+        common_setUp(opj(TRUNK, "osg-build"), "{2018-01-24}")
+        checked_call(["python", "-m", "osgbuild.fetch_sources", "osg-build"])
+        contents = get_listing('osg-build')
 
         self.assertTrue(
             "osg-build.spec" in contents,


### PR DESCRIPTION
Add a new format for .source files specific to GitHub. OSG is pretty committed to GH at this point what with all our software and documentation being hosted there, so adding syntactic sugar shouldn't be a problem. The new format looks like:
```
type=github repo=opensciencegrid/cvmfs-config-osg tag=0.1 hash=e2b54cd1b94c9e3eaee079490c9d85f193c52249
```
which is a shorter version of
```
type=git url=https://github.com/opensciencegrid/cvmfs-config-osg.git tag=0.1 hash=e2b54cd1b94c9e3eaee079490c9d85f193c52249
```