### PR TITLE
handle heavy-weight tags for upstream (SOFTWARE-3453)

### DIFF
--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -123,7 +123,7 @@ def process_meta_url(line, destdir, nocheck):
                 if rc:
                     raise Error("Repository %s does not contain a tag named %s." % (git_url, tag))
                 sha1 = output.split()[0]
-                if sha1 != git_hash:
+                if sha1 != git_hash and deref_git_sha(sha1) != deref_git_sha(git_hash):
                     msg = "Hash mismatch for %s tag %s\n    expected: %s\n    actual:   %s" % \
                           (git_url, tag, git_hash, sha1)
                     if nocheck:
@@ -169,6 +169,11 @@ def process_meta_url(line, destdir, nocheck):
 
     return files
 
+def deref_git_sha(sha):
+    output, rc = utils.sbacktick(["git", "rev-parse", sha + "^{}"])
+    if rc:
+        raise Error("Git failed to parse rev: '%s'" % sha)
+    return output
 
 def process_dot_source(cache_prefix, sfilename, destdir, nocheck):
     """Read a .source file, fetch any files mentioned in it from the


### PR DESCRIPTION
if the expected hash matches the upstream ref, no need to dereference
them.  otherwise, dereference both (that is, until a non-tag object is
reached) and compare those.

(i am thinking that perhaps only the upstream ref needs to be
dereferenced, since it would be weird for our expected hash to refer to
a heavy-weight tag when the upstream ref does not; nevertheless i don't
really see a reason not to support this fallback.)