### PR TITLE
Support mock version strings of different lengths

### DIFF
--- a/osgbuild/mock.py
+++ b/osgbuild/mock.py
@@ -40,11 +40,7 @@ class Mock(object):
         mock_version_str = utils.backtick(self.mock_cmd + ["--version"]).strip()
         mm = re.match(r"\d+(?:\.\d+)*", mock_version_str)
         if mm:
-            try:
-                self.mock_version = tuple(int(it) for it in mm.group(0).split("."))
-            except TypeError:
-                # this shouldn't happen
-                raise MockError("mock --version returned unexpected output: %s" % mock_version_str)
+            self.mock_version = tuple(int(it) for it in mm.group(0).split("."))
         else:
             raise MockError("mock --version returned unexpected output: %s" % mock_version_str)
 

--- a/osgbuild/mock.py
+++ b/osgbuild/mock.py
@@ -38,9 +38,13 @@ class Mock(object):
         cfg_path = self._init_get_cfg_path()
         self.mock_cmd = ['mock']
         mock_version_str = utils.backtick(self.mock_cmd + ["--version"]).strip()
-        m = re.match(r"(\d+)\.(\d+)\.(\d+)", mock_version_str)
-        if m:
-            self.mock_version = (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+        mm = re.match(r"\d+(?:\.\d+)*", mock_version_str)
+        if mm:
+            try:
+                self.mock_version = tuple(int(it) for it in mm.group(0).split("."))
+            except TypeError:
+                # this shouldn't happen
+                raise MockError("mock --version returned unexpected output: %s" % mock_version_str)
         else:
             raise MockError("mock --version returned unexpected output: %s" % mock_version_str)
 


### PR DESCRIPTION
mock 2.0's version is simply "2.0", not "2.0.0", so fix the
version-detecting regex to handle it.