### PR TITLE
Use a newer Koji on CSL machines

### DIFF
--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -52,7 +52,7 @@ GIT_RESTRICTED_BRANCHES = {
     r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'   : 'versioned',
     r'^(\w*/)?condor-(el\d+)'              : 'condor'}
 
-CSL_KOJI_DIR = "/p/vdt/workspace/koji-1.11.0"
+CSL_KOJI_DIR = "/p/vdt/workspace/koji-1.15.3"
 
 OSG_REMOTE = 'https://github.com/opensciencegrid/Software-Redhat.git'
 OSG_AUTH_REMOTE = 'git@github.com:opensciencegrid/Software-Redhat.git'

--- a/osgbuild/kojiinter.py
+++ b/osgbuild/kojiinter.py
@@ -50,6 +50,7 @@ try:
     # load koji cli (as kojicli) from either somewhere in $PATH or CSL_KOJI_DIR/cli/koji
     # I can't use imp.find_module here to get the values I need because
     # /usr/bin/koji doesn't end in .py
+    sys.path.append(os.path.dirname(os.path.abspath(kojicli_filename)))
     kojicli_filehandle = open(kojicli_filename)
     kojicli_desc = ('', kojicli_filehandle.mode, imp.PY_SOURCE)
     kojicli = imp.load_module('kojicli',


### PR DESCRIPTION
What it says on the tin.

This will let me get rid of the gross hack where I load the `koji` script as a library for the `watch_tasks()` function... stay tuned.