### PR TITLE
el8 support for osg-promote

### DIFF
--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -17,7 +17,7 @@ from=osg-3.5-%s-development
 to=osg-3.5-%s-contrib
 repotag=osg35
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route 3.3-prerelease]
 from=osg-3.3-%s-testing
@@ -38,7 +38,7 @@ from=osg-3.5-%s-testing
 to=osg-3.5-%s-prerelease
 repotag=osg35
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route 3.4-rolling]
 from=osg-3.4-%s-testing
@@ -52,7 +52,7 @@ from=osg-3.5-%s-testing
 to=osg-3.5-%s-rolling
 repotag=osg35
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route 3.3-testing]
 from=osg-3.3-%s-development
@@ -73,35 +73,35 @@ from=osg-3.5-%s-development
 to=osg-3.5-%s-testing
 repotag=osg35
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route hcc]
 from=hcc-%s-testing
 to=hcc-%s-release
 repotag=hcc
 dvers=el6 el7
-extra_dvers=
+extra_dvers=el8
 
 [route upcoming]
 from=osg-upcoming-%s-development
 to=osg-upcoming-%s-testing
 repotag=osgup
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route upcoming-prerelease]
 from=osg-upcoming-%s-testing
 to=osg-upcoming-%s-prerelease
 repotag=osgup
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route upcoming-rolling]
 from=osg-upcoming-%s-testing
 to=osg-upcoming-%s-rolling
 repotag=osgup
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route goc-itb]
 from=osg-3.4-%s-development
@@ -122,14 +122,14 @@ from=osg-3.5-%s-development
 to=devops-%s-itb
 repotag=osg35
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [route devops-production]
 from=devops-%s-itb
 to=devops-%s-production
 repotag=osg35
 dvers=el7
-extra_dvers=
+extra_dvers=el8
 
 [aliases]
 contrib=3.5-contrib


### PR DESCRIPTION
Extra dvers are off by default and have to be specified on the command like, like --el8