### PR TITLE
Drop gross hack used for getting watch_tasks from the koji cli

### DIFF
--- a/rpm/osg-build.spec
+++ b/rpm/osg-build.spec
@@ -73,7 +73,7 @@ Summary:        OSG-Build Mock plugin, allows builds with mock
 %package koji
 Requires:       %{name}-base = %{version}
 Requires:       openssl
-Requires:       koji >= 1.7.0
+Requires:       koji >= 1.13.0
 %if 0%{?rhel} < 7
 Requires:       python-argparse
 %endif


### PR DESCRIPTION
As of koji 1.13, watch_tasks got moved into a separate library which I can import as normal.