### PR TITLE
Set module_hotfixes in mock config

### DIFF
--- a/osgbuild/mock.py
+++ b/osgbuild/mock.py
@@ -52,6 +52,7 @@ class Mock(object):
                 raise MockError("Couldn't find mock config file at " + cfg_abspath)
 
             # The cfg file passed to mock is always relative to /etc/mock
+            # TODO the manpage says if it ends in .cfg, it is interpreted as a full path so this is no longer needed
             self.mock_cmd += ['-r', "../../" + cfg_abspath_no_ext]
 
         self.target_arch = buildopts['target_arch']
@@ -99,6 +100,7 @@ You might need to log out and log in for the changes to take effect""")
             # the way mock does it. Figure out which the user
             # meant (by seeing which interpretation exists) and
             # translate it to what mock wants.
+            # TODO no longer true, see above
             if not mock_config.endswith(".cfg"):
                 given_cfg_path = mock_config + ".cfg"
             else:


### PR DESCRIPTION
Doing el8 builds in osg-build mock sometimes fails with errors like
```
No available modular metadata for modular package 'perl-Carp-1.50-439.module_el8.3.0+406+78614513.noarch', it cannot be installed on the system
No available modular metadata for modular package 'perl-Encode-4:3.01-439.module_el8.3.0+406+78614513.x86_64', it cannot be installed on the system
No available modular metadata for modular package 'perl-Errno-1.30-451.module_el8.3.0+406+78614513.x86_64', it cannot be installed on the system
...
Error: No available modular metadata for modular package
```
The fix for that is to add the `module_hotfixes=1` option to the `yum.conf` files generated by Koji. Mock configs generated by Koji for Koji builds are fine -- we set the `mock.yum.module_hotfixes=1` tag option in the EL8 Koji build tags which takes care the issue.

However, the mock configs you get when you run `koji mock-config ...` or `osg-build mock --mock-config-from-koji ...` use a different code path and cannot be configured to set that flag.

Instead, I have osg-build modify the resulting mock config to set the variable. It's a nasty hack but it's required to get sourceless builds to work.

*Note:* this appears to be fixed in newer versions of the Koji client so I will be able to remove this hack once we get around to updating to it.