### PR TITLE
Allow building from `trunk` branch to `osg-3.5-el*` targets and from `osg-3.5` branch to `osg-el*` targets

### DIFF
--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -52,9 +52,6 @@ GIT_RESTRICTED_BRANCHES = {
     r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'   : 'versioned',
     r'^(\w*/)?condor-(el\d+)'              : 'condor'}
 
-MAIN_OSGVER = '3.5'
-UPCOMING_OSGVER = '3.5'
-
 CSL_KOJI_DIR = "/p/vdt/workspace/koji-1.15.3"
 
 OSG_REMOTE = 'https://github.com/opensciencegrid/Software-Redhat.git'

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -52,6 +52,9 @@ GIT_RESTRICTED_BRANCHES = {
     r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'   : 'versioned',
     r'^(\w*/)?condor-(el\d+)'              : 'condor'}
 
+MAIN_OSGVER = '3.5'
+UPCOMING_OSGVER = '3.5'
+
 CSL_KOJI_DIR = "/p/vdt/workspace/koji-1.15.3"
 
 OSG_REMOTE = 'https://github.com/opensciencegrid/Software-Redhat.git'

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -152,13 +152,14 @@ def is_restricted_target(target):
     return False
 
 def restricted_branch_matches_target(branch, target):
-    """Return True if the pattern that matches 'branch' is associated with the
-    same name (e.g. 'main', 'upcoming', 'versioned') as the pattern that
-    matches 'target'; False otherwise.
+    """Return True if the pattern that matches `branch` is associated with the
+    same name (e.g. 'devops', 'main', 'upcoming', 'versioned') as the pattern that
+    matches `target`; False otherwise.
     Special cases:
-    - if the name is 'versioned' (e.g. we're building from branches/osg-3.1) then the versions also have to match.
-    - if the name is 'upcoming' (e.g. building from branches/3.6-upcoming) then the versions also have to match
-        (treat a missing version ("branches/upcoming") as "3.5")
+    - if the name is 'versioned' (e.g. we're building from 'branches/osg-3.1') then the versions also have to match.
+    - treat 'main' (i.e. 'trunk') as 'versioned' with a version of '3.5'
+    - if the name is 'upcoming' (e.g. building from 'branches/3.6-upcoming') then the versions also have to match.
+      treat a missing version ('branches/upcoming') as '3.5'
 
     Precondition: is_restricted_branch(branch) and is_restricted_target(target)
     are True.

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -5,7 +5,7 @@ import re
 import os
 import errno
 
-from .constants import SVN_ROOT, SVN_REDHAT_PATH, SVN_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS, MAIN_OSGVER, UPCOMING_OSGVER
+from .constants import SVN_ROOT, SVN_REDHAT_PATH, SVN_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
 from .error import Error, SVNError, UsageError
 from . import utils
 
@@ -177,13 +177,13 @@ def restricted_branch_matches_target(branch, target):
             target_osgver = target_match.groupdict().get("osgver", None)
             branch_osgver = branch_match.groupdict().get("osgver", None)
             if branch_name == "main":
-                branch_osgver = MAIN_OSGVER
+                branch_osgver = "3.5"
             if target_name == "main":
-                target_osgver = MAIN_OSGVER
+                target_osgver = "3.5"
             if branch_name == "upcoming":
-                branch_osgver = branch_osgver or UPCOMING_OSGVER
+                branch_osgver = branch_osgver or "3.5"
             if target_name == "upcoming":
-                target_osgver = target_osgver or UPCOMING_OSGVER
+                target_osgver = target_osgver or "3.5"
 
             if target_name in ["main", "versioned"] and branch_name in ["main", "versioned"]:
                 return branch_osgver == target_osgver

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -165,32 +165,39 @@ def restricted_branch_matches_target(branch, target):
     are True.
 
     """
+    branch_match = branch_name = target_match = target_name = None
     for (branch_pattern, branch_name) in SVN_RESTRICTED_BRANCHES.items():
         branch_match = re.search(branch_pattern, branch)
-        if not branch_match:
-            continue
-        for (target_pattern, target_name) in KOJI_RESTRICTED_TARGETS.items():
-            target_match = re.search(target_pattern, target)
-            if not target_match:
-                continue
+        if branch_match:
+            break
+    if not branch_match:
+        return False
 
-            target_osgver = target_match.groupdict().get("osgver", None)
-            branch_osgver = branch_match.groupdict().get("osgver", None)
-            if branch_name == "main":
-                branch_osgver = "3.5"
-            if target_name == "main":
-                target_osgver = "3.5"
-            if branch_name == "upcoming":
-                branch_osgver = branch_osgver or "3.5"
-            if target_name == "upcoming":
-                target_osgver = target_osgver or "3.5"
+    for (target_pattern, target_name) in KOJI_RESTRICTED_TARGETS.items():
+        target_match = re.search(target_pattern, target)
+        if target_match:
+            break
+    if not target_match:
+        return False
 
-            if target_name in ["main", "versioned"] and branch_name in ["main", "versioned"]:
-                return branch_osgver == target_osgver
-            elif target_name == "upcoming" and branch_name == "upcoming":
-                return branch_osgver == target_osgver
-            elif target_name == branch_name:
-                return True
+    branch_osgver = branch_match.groupdict().get("osgver", None)
+    target_osgver = target_match.groupdict().get("osgver", None)
+    if branch_name == "main":
+        branch_name = "versioned"
+        branch_osgver = "3.5"
+    if target_name == "main":
+        target_name = "versioned"
+        target_osgver = "3.5"
+    if branch_name == "upcoming":
+        branch_osgver = branch_osgver or "3.5"
+    if target_name == "upcoming":
+        target_osgver = target_osgver or "3.5"
+
+    if branch_name != target_name:
+        return False
+
+    if branch_name in ["upcoming", "versioned"]:
+        return branch_osgver == target_osgver
 
     return False
 


### PR DESCRIPTION
[SOFTWARE-4411](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4411)

Lets `osg-build koji --repo 3.5` work in `trunk` and lets `osg-build koji` (w/o the repo) work in `branches/osg-3.5` (once we create it).