### PR TITLE
Make OSG 3.6 the default target release series (SOFTWARE-5208)

### DIFF
--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -194,12 +194,12 @@ def restricted_branch_matches_target(branch, target):
         branch_osgver = "3.5"
     if target_name == "main":
         target_name = "versioned"
-        target_osgver = "3.5"
+        target_osgver = "3.6"
     # Deal with "upcoming", which is the same as "3.5-upcoming"
     if branch_name == "upcoming":
         branch_osgver = branch_osgver or "3.5"
     if target_name == "upcoming":
-        target_osgver = target_osgver or "3.5"
+        target_osgver = target_osgver or "3.6"
 
     # branch_osgver and target_osgver might be None, e.g. for devops but that's OK
     return (branch_name == target_name) and (branch_osgver == target_osgver)


### PR DESCRIPTION
With `master`

```
blin@blin-work:~/pkgs/redhat/branches/osg-3.6/voms.el8$ osg-build koji .
-------------------------------------------------------------------------------
SVN error: Forbidden to build from branches/osg-3.6 branch into osg-el7 target
-------------------------------------------------------------------------------
blin@blin-work:~/pkgs/redhat/branches/3.6-upcoming/osg-flock$ osg-build koji --repo upcoming .
-------------------------------------------------------------------------------
SVN error: Forbidden to build from branches/3.6-upcoming branch into osg-upcoming-el8 target
-------------------------------------------------------------------------------
```

With this branch:

```
blin@blin-work:~/pkgs/redhat/branches/3.6-upcoming/osg-flock$ osg-build koji --repo upcoming .
 >> Ignoring use_old_ssl: only supported on Python 2
 >> Initializing koji session to http://koji.opensciencegrid.org/kojihub
 >> Logging in to koji as Brian Lin A2266246
<snip>
blin@blin-work:~/pkgs/redhat/branches/osg-3.6/voms.el8$ osg-build koji .
 >> Ignoring use_old_ssl: only supported on Python 2
 >> Initializing koji session to http://koji.opensciencegrid.org/kojihub
 >> Logging in to koji as Brian Lin A2266246
<snip>
```