### PR TITLE
Switch fetch-dot-source to Python3

### DIFF
--- a/fetch-dot-source
+++ b/fetch-dot-source
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import logging
 import getopt
 import sys


### PR DESCRIPTION
mostly because /usr/bin/python is not available on many places anymore.