### PR TITLE
Fix default Koji configs:

### DIFF
--- a/data/osg-koji-home.conf
+++ b/data/osg-koji-home.conf
@@ -1,11 +1,13 @@
 [koji]
 ;configuration for koji cli tool
+srv = koji.opensciencegrid.org
+
 ;url of XMLRPC server
-server = http://koji.opensciencegrid.org/kojihub
+server = https://%(srv)s/kojihub
 ;url of web interface
-weburl = http://koji.opensciencegrid.org/koji
+weburl = https://%(srv)s/koji
 ;url for koji file access
-topurl = http://koji.opensciencegrid.org
+topurl = https://%(srv)s/kojifiles
 
 ; use_old_ssl uses koji.compatrequests instead of requests
 ; This allows our passphrase caching patches to work.

--- a/data/osg-koji-site.conf
+++ b/data/osg-koji-site.conf
@@ -1,19 +1,23 @@
 [koji]
 ;configuration for koji cli tool
+srv = koji.opensciencegrid.org
+
 ;url of XMLRPC server
-server = http://koji.opensciencegrid.org/kojihub
+server = https://%(srv)s/kojihub
 ;url of web interface
-weburl = http://koji.opensciencegrid.org/koji
-;url of package download site
-pkgurl = http://koji.opensciencegrid.org/packages
-;path to the koji top directory
-topdir = /mnt/koji
+weburl = https://%(srv)s/koji
+;url for koji file access
+topurl = https://%(srv)s/kojifiles
+
+; use_old_ssl uses koji.compatrequests instead of requests
+; This allows our passphrase caching patches to work.
+; Set use_old_ssl=True unless using a grid proxy.
+use_old_ssl = True
+
 ;configuration for SSL authentication
 authtype = ssl
 ;client certificate
 cert = ~/.koji/client.crt
-;certificate of the CA that issued the client certificate
-ca = /etc/pki/tls/certs/ca-bundle.crt
 ;certificate of the CA that issued the HTTP server certificate
 serverca = /etc/pki/tls/certs/ca-bundle.crt
 


### PR DESCRIPTION
- Use a constant for the server instead of hardcoding it
- Use https
- Fix the "topurl" which is used for Koji file access -- this was breaking `koji download-build`
- Drop unused "ca" option
- Bring osg-koji-site.conf up to date with osg-koji-home.conf