### PR TITLE
Match tags for osg-23-internal

### DIFF
--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -254,6 +254,7 @@ def repo_hints(targets):
                 osg_match = re.match(r'osg-([0-9.]+)-el\d+', target)
                 osg_main_match = re.match(r'osg-(\d+)-main-el\d+', target)
                 osg_upcoming_match = re.match(r'osg-([0-9.]+)-upcoming-el\d+', target)
+                osg_internal_match = re.match(r'osg-(\d+)-internal-el\d+', target)
                 if osg_match:
                     osgver = osg_match.group(1)
                     __repo_hints_cache[osgver] = __repo_hints_cache['osg-%s' % osgver] = {'target': 'osg-%s-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
@@ -263,6 +264,9 @@ def repo_hints(targets):
                 elif osg_upcoming_match:
                     osgver = osg_upcoming_match.group(1)
                     __repo_hints_cache["%s-upcoming" % osgver] = {'target': 'osg-%s-upcoming-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
+                elif osg_internal_match:
+                    osgver = osg_internal_match.group(1)
+                    __repo_hints_cache["%s-internal" % osgver] = {'target': 'osg-%s-internal-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
 
     return __repo_hints_cache
 


### PR DESCRIPTION
Needed for `osg-build koji` to recognize `--repo 23-internal` as valid arguments.