### PR TITLE
Drop trunk, fix tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ TESTDIR = $(PYDIR)/test
 SVNDATADIR = data
 MAIN_SCRIPT = $(NAME)
 EXTRA_SCRIPTS = koji-tag-diff osg-import-srpm osg-koji osg-promote koji-blame
-MAIN_TEST_SYMLINK = osg-build-test
+TEST_SCRIPT = osg-build-test
 MAIN_TEST = $(TESTDIR)/test_osgbuild.py
 PYTHON_SITELIB := $(shell $(PYTHON) -c "import sysconfig; print(sysconfig.get_paths()['platlib'])")
 BINDIR = /usr/bin
@@ -41,12 +41,13 @@ install: install-common
 
 	mkdir -p $(DESTDIR)/$(PYTHON_SITELIB)/$(TESTDIR)
 	install -p -m 755 $(TESTDIR)/*.py $(DESTDIR)/$(PYTHON_SITELIB)/$(TESTDIR)
+	install -p -m 755 $(TEST_SCRIPT) $(DESTDIR)/$(BINDIR)
+	sed -ri '1s,^#!/usr/bin/env python.*,#!$(PYTHON),' $(DESTDIR)/$(BINDIR)/$(TEST_SCRIPT)
 
-	ln -snf $(PYTHON_SITELIB)/$(MAIN_TEST) $(DESTDIR)/$(BINDIR)/$(MAIN_TEST_SYMLINK)
 
 dist:
 	mkdir -p $(NAME_VERSION)
-	cp -rp $(MAIN_SCRIPT) $(EXTRA_SCRIPTS) $(PYDIR) $(SVNDATADIR) Makefile pylintrc $(NAME_VERSION)/
+	cp -rp $(MAIN_SCRIPT) $(EXTRA_SCRIPTS) $(TEST_SCRIPT) $(PYDIR) $(SVNDATADIR) Makefile pylintrc $(NAME_VERSION)/
 	tar czf $(NAME_VERSION).tar.gz $(NAME_VERSION)/ --exclude='*/.svn*' --exclude='*/*.py[co]' --exclude='*/*~'
 
 check:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # version now specified in osgbuild/version.py
-PYTHON = python
+PYTHON ?= python3
+PYTHON := $(shell which $(PYTHON) )
 VERSION := $(shell $(PYTHON) -c "import sys; sys.path.insert(0, '.'); from osgbuild import version; sys.stdout.write(version.__version__ + '\n')")
 HASH := $(shell git rev-parse HEAD)
 NAME = osg-build

--- a/osg-build-test
+++ b/osg-build-test
@@ -1,1 +1,39 @@
-osgbuild/test/test_osgbuild.py
+#!/bin/bash
+
+: "${PYTHON:=python3}"
+if ! "${PYTHON}" -c 'import sys; sys.exit(0)'; then
+    echo '`'${PYTHON}'`' is not a useable Python interpreter
+    exit 127
+fi
+
+ret=0
+ret1=
+ret2=
+"${PYTHON}" -m "osgbuild.test.test_osgbuild"
+ret1=$?
+ret=$((ret | ret1))
+if command -v koji &>/dev/null; then
+    if [[ -d $HOME/.osg-koji ]]; then
+        "${PYTHON}" -m "osgbuild.test.test_osgbuild_koji"
+        ret2=$?
+        ret=$((ret | ret2))
+    else
+        echo "$HOME/.osg-koji not found; skipping koji tests."
+    fi
+else
+    echo "koji binary not found; skipping koji tests."
+fi
+
+if [[ -n $ret1 ]]; then
+    echo "Common tests returned $ret1"
+else
+    echo "Common tests skipped"
+fi
+
+if [[ -n $ret2 ]]; then
+    echo "Koji tests returned $ret2"
+else
+    echo "Koji tests skipped."
+fi
+
+exit $ret

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -31,8 +31,7 @@ SVN_ROOT = "https://vdt.cs.wisc.edu/svn"
 SVN_REDHAT_PATH = "/native/redhat"
 
 SVN_RESTRICTED_BRANCHES = {
-    r'^trunk$'                             : 'main',
-    r'^branches/(?P<osgver>[0-9.]+)-?upcoming$': 'upcoming',
+    r'^branches/(?P<osgver>[0-9.]+)-upcoming$': 'upcoming',
     r'^branches/osg-internal$'             : 'oldinternal',
     r'^branches/devops$'                   : 'devops',
     r'^branches/osg-(?P<osgver>\d+\.\d+)$' : 'versioned',
@@ -41,7 +40,7 @@ SVN_RESTRICTED_BRANCHES = {
 }
 KOJI_RESTRICTED_TARGETS = {
     r'^osg-(el\d+)$'                       : 'main',
-    r'^osg-(?P<osgver>[0-9.]+)-?upcoming-(el\d+)$': 'upcoming',
+    r'^osg-(?P<osgver>[0-9.]+)-upcoming-(el\d+)$': 'upcoming',
     r'^devops-(el\d+)$'                    : 'devops',
     r'^osg-(el\d+)-internal$'              : 'oldinternal',
     r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'  : 'versioned',
@@ -49,8 +48,7 @@ KOJI_RESTRICTED_TARGETS = {
     r'^(?P<osgver>[0-9.]+)-internal-(el\d+)$' : 'internal',
 }
 GIT_RESTRICTED_BRANCHES = {
-    r'^(\w*/)?master$'                     : 'main',
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-?upcoming$': 'upcoming',
+    r'^(\w*/)?(?P<osgver>[0-9.]+)-upcoming$': 'upcoming',
     r'^(\w*/)?internal$'                   : 'oldinternal',
     r'^(\w*/)?devops$'                     : 'devops',
     r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'   : 'versioned',

--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -533,6 +533,10 @@ if __name__ == '__main__':
         for arg in sys.argv[1:]:
             if arg == "--nocheck":
                 nocheck = True
+            elif arg == "--quiet":
+                log.setLevel(logging.ERROR)
+            elif arg == "--debug":
+                log.setLevel(logging.DEBUG)
             else:
                 package_dirs.append(arg)
     try:

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -144,12 +144,9 @@ def restricted_branch_matches_target(branch, target):
     target_osgver = target_match.groupdict().get("osgver", None)
 
     # Deal with "main" (i.e. the "trunk" branch or the "osg-elX" targets), which are aliases for "3.5"
-    if branch_name == "main":
-        branch_name = "versioned"
-        branch_osgver = "3.5"
     if target_name == "main":
         target_name = "versioned"
-        target_osgver = "3.5"
+        target_osgver = "3.6"
 
     # branch_osgver and target_osgver might be None, e.g. for devops but that's OK
     return (branch_name == target_name) and (branch_osgver == target_osgver)

--- a/osgbuild/mock.py
+++ b/osgbuild/mock.py
@@ -160,8 +160,13 @@ You might need to log out and log in for the changes to take effect""")
         if self.target_arch:
             rebuild_cmd += ['--arch', self.target_arch]
         if self.mock_version >= (1,4,0):
-            # systemd-nspawn is often broken; don't use it. network is required for maven builds :(
-            rebuild_cmd += ['--enable-network', '--config-opts=use_nspawn=False']
+            # network is required for maven builds :(
+            rebuild_cmd += ['--enable-network']
+            # systemd-nspawn is often broken (especially in a container); don't use it
+            if self.mock_version < (5,):
+                rebuild_cmd += ['--config-opts=use_nspawn=False']
+            else:  # same thing, different syntax
+                rebuild_cmd += ['--isolation=simple']
             if int(self.buildopts["redhat_release"]) >= 8 and utils.get_local_machine_release() < 8:
                 rebuild_cmd += ["--bootstrap-chroot"]
         else:

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -190,10 +190,6 @@ def restricted_branch_matches_target(branch, target):
     branch_osgver = branch_match.groupdict().get("osgver", None)
     target_osgver = target_match.groupdict().get("osgver", None)
 
-    # Deal with "main" (i.e. the "trunk" branch or the "osg-elX" targets), which are aliases for "3.5"
-    if branch_name == "main":
-        branch_name = "versioned"
-        branch_osgver = "3.5"
     if target_name == "main":
         target_name = "versioned"
         target_osgver = "3.6"
@@ -203,13 +199,18 @@ def restricted_branch_matches_target(branch, target):
 
 def verify_correct_branch(package_dir, buildopts):
     """Check that the user is not trying to build with bad branch/target
-    combinations. For example, building from trunk into upcoming, or building
-    from osg-3.1 into osg-3.2.
+    combinations. For example, building from osg-3.6 into 3.6-upcoming, or building
+    from osg-3.6 into 23-main.
 
     """
     package_info = get_package_info(package_dir)
     url = package_info['canon_url']
-    branch_match = re.search(SVN_REDHAT_PATH + r'/(trunk|branches/[^/]+)/', url)
+    # Check for old, deprecated branches
+    if SVN_REDHAT_PATH + '/trunk/' in url:
+        raise SVNError("trunk has been removed; use branches/osg-3.5 instead")
+    elif SVN_REDHAT_PATH + '/branches/upcoming/' in url:
+        raise SVNError("unversioned upcoming has been removed; use branches/3.5-upcoming instead")
+    branch_match = re.search(SVN_REDHAT_PATH + r'/(branches/[^/]+)/', url)
     if not branch_match:
         # Building from a weird path (such as a tag). Be permissive -- koji
         # itself will catch building from outside SVN so we don't have to

--- a/osgbuild/test/common.py
+++ b/osgbuild/test/common.py
@@ -1,0 +1,79 @@
+import atexit
+import os
+import re
+import shutil
+import sys
+import tempfile
+from os.path import join as opj
+
+from osgbuild import constants as C
+
+try:
+    # type checking, if avaliable
+    from typing import List, Optional
+except ImportError:  # Python 2
+    List = Optional = None
+
+from osgbuild.utils import find_file, errprintf, checked_backtick, checked_call, CalledProcessError
+
+OSG_36 = "native/redhat/branches/osg-3.6"
+OSG_36_UPCOMING = "native/redhat/branches/3.6-upcoming"
+OSG_23_MAIN = "native/redhat/branches/23-main"
+OSG_23_UPCOMING = "native/redhat/branches/23-upcoming"
+
+
+def regex_in_list(pattern, listing):
+    return [x for x in listing if re.match(pattern, x)]
+
+
+__osg_build_path_cache = None
+def get_osg_build_path():
+    # type: () -> str
+    global __osg_build_path_cache
+
+    if not __osg_build_path_cache:
+        __osg_build_path_cache = find_file("osg-build",
+                                           [os.getcwd()] + os.environ["PATH"].split(":"))
+        if not __osg_build_path_cache:
+            errprintf("osg-build script not found!")
+            sys.exit(127)
+
+    return __osg_build_path_cache
+
+
+def go_to_temp_dir():
+    working_dir = tempfile.mkdtemp(prefix="osg-build-test-")
+    atexit.register(shutil.rmtree, working_dir, ignore_errors=True, onerror=None)
+    os.chdir(working_dir)
+    return working_dir
+
+
+def common_setUp(path, rev):
+    """Create a temporary directory, ensure it gets deleted on exit, cd to it,
+    and check out a specific revision of a path from our SVN.
+
+    """
+    working_dir = go_to_temp_dir()
+    svn_export(path, rev, os.path.basename(path))
+    return opj(working_dir, os.path.basename(path))
+
+
+def backtick_osg_build(cmd_args, *args, **kwargs):
+    kwargs['clocale'] = True
+    kwargs['err2out'] = True
+    return checked_backtick([get_osg_build_path()] + cmd_args, *args, **kwargs)
+
+
+def checked_osg_build(cmd_args, *args, **kwargs):
+    return checked_call([get_osg_build_path()] + cmd_args, *args, **kwargs)
+
+
+def svn_export(path, rev, destpath):
+    """Run svn export on a revision rev of path into destpath"""
+    try:
+        checked_backtick(
+            ["svn", "export", opj(C.SVN_ROOT, path) + "@" + rev, "-r", rev, destpath],
+            err2out=True)
+    except CalledProcessError as err:
+        errprintf("Error in svn export:\n%s", err.output)
+        raise

--- a/osgbuild/test/common.py
+++ b/osgbuild/test/common.py
@@ -26,21 +26,6 @@ def regex_in_list(pattern, listing):
     return [x for x in listing if re.match(pattern, x)]
 
 
-__osg_build_path_cache = None
-def get_osg_build_path():
-    # type: () -> str
-    global __osg_build_path_cache
-
-    if not __osg_build_path_cache:
-        __osg_build_path_cache = find_file("osg-build",
-                                           [os.getcwd()] + os.environ["PATH"].split(":"))
-        if not __osg_build_path_cache:
-            errprintf("osg-build script not found!")
-            sys.exit(127)
-
-    return __osg_build_path_cache
-
-
 def go_to_temp_dir():
     working_dir = tempfile.mkdtemp(prefix="osg-build-test-")
     atexit.register(shutil.rmtree, working_dir, ignore_errors=True, onerror=None)
@@ -61,11 +46,11 @@ def common_setUp(path, rev):
 def backtick_osg_build(cmd_args, *args, **kwargs):
     kwargs['clocale'] = True
     kwargs['err2out'] = True
-    return checked_backtick([get_osg_build_path()] + cmd_args, *args, **kwargs)
+    return checked_backtick([sys.executable, "-m", "osgbuild.main"] + cmd_args, *args, **kwargs)
 
 
 def checked_osg_build(cmd_args, *args, **kwargs):
-    return checked_call([get_osg_build_path()] + cmd_args, *args, **kwargs)
+    return checked_call([sys.executable, "-m", "osgbuild.main"] + cmd_args, *args, **kwargs)
 
 
 def svn_export(path, rev, destpath):

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -27,8 +27,10 @@ from osgbuild.utils import (
     errprintf,
     unslurp)
 
-TRUNK = "native/redhat/trunk"
-DEVOPS = "native/redhat/branches/devops"
+OSG_36 = "native/redhat/branches/osg-3.6"
+OSG_36_UPCOMING = "native/redhat/branches/3.6-upcoming"
+OSG_23_MAIN = "native/redhat/branches/23-main"
+OSG_23_UPCOMING = "native/redhat/branches/23-upcoming"
 
 initial_wd = os.getcwd()
 osg_build_path = find_file('osg-build', [initial_wd,
@@ -92,7 +94,7 @@ class TestLint(TestCase):
     """Tests for 'lint' task"""
 
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(TRUNK, "condor"), "{2018-06-27}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "condor"), "{2023-07-21}")
 
     def test_lint(self):
         out = backtick_osg_build(["lint", self.pkg_dir])
@@ -114,8 +116,8 @@ class TestRpmbuild(TestCase):
     """Tests for 'rpmbuild' task"""
 
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(TRUNK, "osg-build"),
-                                    "{2018-06-01}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
+                                    "{2023-07-21}")
 
     def test_rpmbuild(self):
         out = backtick_osg_build(["rpmbuild", self.pkg_dir])
@@ -133,69 +135,66 @@ class TestPrebuild(TestCase):
     """Tests for 'prebuild' task"""
 
     def test_prebuild(self):
-        pkg_dir = common_setUp(opj(TRUNK, "mash"),
-                               "{2011-12-08}")
+        pkg_dir = common_setUp(opj(OSG_36, "xrootd"),
+                               "{2023-07-21}")
         checked_osg_build(["prebuild", pkg_dir])
         upstream_contents = get_listing(opj(pkg_dir, C.WD_UNPACKED))
         final_contents = get_listing(opj(pkg_dir, C.WD_PREBUILD))
 
         self.assertTrue(
-            "mash.spec" in upstream_contents,
+            "xrootd.spec" in upstream_contents,
             "spec file not in upstream contents")
         self.assertTrue(
-            "mash-0.5.22.tar.gz" in upstream_contents,
+            "xrootd.tar.gz" in upstream_contents,
             "source tarball not in upstream contents")
         self.assertTrue(
-            "mash.spec" in final_contents,
+            "xrootd.spec" in final_contents,
             "spec file not in final contents")
         self.assertTrue(
-            "multilib-python.patch" in final_contents,
+            "1868-env-hostname-override.patch" in final_contents,
             "osg patch not in final contents")
         self.assertTrue(
-            regex_in_list(r"mash-0[.]5[.]22-2[.]osg[.]el\d[.]src[.]rpm", final_contents),
+            regex_in_list(r"xrootd-5[.]6[.]1-1[.]1[.]osg[.]el\d+[.]src[.]rpm", final_contents),
             "srpm not successfully built")
 
     def test_prebuild_osgonly(self):
-        pkg_osgonly_dir = common_setUp(opj(TRUNK, "osg-build"),
-                                       "{2018-06-01}")
+        pkg_osgonly_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
+                                       "{2023-07-21}")
         checked_osg_build(["prebuild", pkg_osgonly_dir])
         final_contents = get_listing(opj(pkg_osgonly_dir, C.WD_PREBUILD))
 
         self.assertTrue(
             regex_in_list(
-                r"osg-build-1[.]12[.]2-1[.]osg[.]el\d[.]src[.]rpm",
+                r"osg-xrootd-3[.]6-20[.]osg[.]el\d+[.]src[.]rpm",
                 final_contents),
             "srpm not successfully built")
 
     def test_prebuild_passthrough(self):
-        pkg_passthrough_dir = common_setUp(opj(TRUNK, "osg-build"),
-                                           "{2018-06-01}")
+        pkg_passthrough_dir = common_setUp(opj(OSG_36, "htgettoken"),
+                                           "{2023-07-21}")
         checked_osg_build(["prebuild", pkg_passthrough_dir])
         final_contents = get_listing(opj(pkg_passthrough_dir, C.WD_PREBUILD))
 
         self.assertTrue(
             regex_in_list(
-                r"osg-build-1[.]12[.]2-1[.]osg[.]el\d[.]src[.]rpm",
+                r"htgettoken-1[.]18-1[.]osg[.]el\d+[.]src[.]rpm",
                 final_contents),
             "srpm not successfully built")
 
     def test_prebuild_full_extract(self):
-        pkg_dir = common_setUp(opj(TRUNK, "mash"),
-                               "{2011-12-08}")
+        pkg_dir = common_setUp(opj(OSG_36, "xrootd-multiuser"),
+                               "{2023-07-21}")
         out = backtick_osg_build(["prebuild", "--full-extract", pkg_dir])
         ut_contents = get_listing(opj(pkg_dir, C.WD_UNPACKED_TARBALL))
         tarball_contents = get_listing(opj(pkg_dir, C.WD_UNPACKED_TARBALL,
-                                           "mash-0.5.22"))
+                                           "xrootd-multiuser-2.1.3"))
 
         self.assertNotRegexpMatches(
             out,
             re.escape("cpio: premature end of archive"),
             "file unreadable by cpio")
         self.assertTrue(
-            "mash.spec" in ut_contents,
-            "spec file not in unpacked tarball dir")
-        self.assertTrue(
-            "README" in tarball_contents,
+            "README.md" in tarball_contents,
             "expected file not in unpacked sources")
 # end of TestPrebuild
 
@@ -204,15 +203,15 @@ class TestPrepare(TestCase):
     """Tests for 'prepare' task"""
 
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(TRUNK, "mash"),
-                                    "{2018-06-27}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "xrootd-multiuser"),
+                                    "{2023-07-21}")
 
     def test_prepare(self):
         checked_osg_build(["prepare", self.pkg_dir])
-        srcdir = opj(self.pkg_dir, C.WD_RESULTS, "BUILD", "mash-0.5.22")
+        srcdir = opj(self.pkg_dir, C.WD_RESULTS, "BUILD", "xrootd-multiuser-2.1.3")
         self.assertTrue(os.path.exists(srcdir), "SRPM not unpacked")
         try:
-            checked_call(["grep", "-q", "LCMAPS plugins", opj(srcdir, "mash/multilib.py")])
+            checked_call(["grep", "-Fq", "ThreadSetgroups(0, nullptr)", opj(srcdir, "src/UserSentry.hh")])
         except CalledProcessError:
             self.fail("Patches not applied")
 
@@ -228,31 +227,31 @@ class TestFetch(TestCase):
         return get_listing(pdir)
 
     def test_cache_fetch(self):
-        common_setUp(opj(DEVOPS, "mash"), "{2019-10-01}")
-        contents = self.fetch_sources("mash")
+        common_setUp(opj(OSG_36, "xrootd"), "{2023-07-21}")
+        contents = self.fetch_sources("xrootd")
 
         self.assertTrue(
-            "mash.spec" in contents,
+            "xrootd.spec" in contents,
             "spec file not found")
         self.assertTrue(
-            "mash-0.5.22.tar.gz" in contents,
+            "xrootd.tar.gz" in contents,
             "source tarball not found")
         head_out = checked_backtick(
-            ["head", "-n", "15", "mash/mash.spec"])
+            ["head", "-n", "1", "xrootd/xrootd.spec"])
         self.assertRegexpMatches(
             head_out,
-            r"Patch0:\s+multilib-python.patch",
+            r"# OSG additions",
             "Spec file not overridden")
 
     def test_git_fetch(self):
-        common_setUp(opj(DEVOPS, "osg-build"), "{2020-07-01}")
-        contents = self.fetch_sources("osg-build")
+        common_setUp(opj(OSG_36, "xrootd-multiuser"), "{2023-07-21}")
+        contents = self.fetch_sources("xrootd-multiuser")
 
         self.assertTrue(
-            "osg-build.spec" in contents,
+            "xrootd-multiuser.spec" in contents,
             "spec file not found")
         self.assertTrue(
-            "osg-build-1.16.2.tar.gz" in contents,
+            "xrootd-multiuser-2.1.3.tar.gz" in contents,
             "source tarball not found")
 
     def test_git_fetch_with_release(self):
@@ -329,8 +328,8 @@ class TestMock(TestCase):
     """Tests for mock"""
 
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(DEVOPS, "koji"),
-                                    "{2021-01-27}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
+                                    "{2023-07-21}")
 
     def check_for_mock_group(self):
         username = pwd.getpwuid(os.getuid()).pw_name
@@ -356,8 +355,8 @@ class TestKoji(TestCase):
     """Tests for koji"""
 
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(DEVOPS, "koji"),
-                                    "{2021-01-27}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
+                                    "{2023-07-21}")
 
     kdr_shell = ["koji", "--dry-run", "--koji-backend=shell"]
     kdr_lib = ["koji", "--dry-run", "--koji-backend=kojilib"]
@@ -371,25 +370,27 @@ class TestKoji(TestCase):
 
     def test_koji_shell_args1(self):
         output = backtick_osg_build(self.kdr_shell + ["--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-el7", output),
+        self.assertTrue(self.is_building_for("osg.+el7", output),
                         "not building for el7")
-        self.assertTrue(self.is_building_for("osg-el8", output),
+        self.assertTrue(self.is_building_for("osg.+el8", output),
                         "not building for el8")
+        self.assertTrue(self.is_building_for("osg.+el9", output),
+                        "not building for el9")
 
     def test_koji_shell_args2(self):
         output = backtick_osg_build(self.kdr_shell + ["--el7", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-el7", output),
+        self.assertTrue(self.is_building_for("osg.+el7", output),
                         "not building for el7")
-        self.assertFalse(self.is_building_for("osg-el8", output),
+        self.assertFalse(self.is_building_for("osg.+el8", output),
                          "falsely building for el8")
 
     def test_koji_shell_args3(self):
         output = backtick_osg_build(self.kdr_shell + ["--ktt", "osg-el8", "--scratch", self.pkg_dir])
         self.assertFalse(
-            self.is_building_for("osg-el7", output),
+            self.is_building_for("osg.+el7", output),
             "falsely building for el7")
         self.assertTrue(
-            self.is_building_for("osg-el8", output),
+            self.is_building_for("osg.+el8", output),
             "not building for el8 for the right target")
 
     def test_koji_shell_args4(self):
@@ -403,44 +404,11 @@ class TestKoji(TestCase):
         output = backtick_osg_build(self.kdr_lib + ["--scratch", self.pkg_dir])
         out_list = output.split("\n")
         self.assertTrue(
-            regex_in_list(r".*kojisession.build\([^,]+?, 'osg-el[78]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
-
-    def test_koji_lib_old_upcoming(self):
-        output = backtick_osg_build(self.kdr_lib + ["--upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-upcoming-el8", output))
-
-    def test_koji_lib_old_upcoming2(self):
-        output = backtick_osg_build(self.kdr_lib + ["--upcoming", "--scratch", "--el7", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-upcoming-el7", output))
-        self.assertFalse(self.is_building_for("osg-upcoming-el8", output))
-
-    def test_koji_lib_old_upcoming3(self):
-        output = backtick_osg_build(self.kdr_lib + ["--repo", "upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-upcoming-el8", output))
-
-    def test_koji_shell_old_upcoming(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el7", "--upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(
-            self.is_building_for("osg-upcoming-el7", output),
-            "not building for el7-upcoming")
-        self.assertFalse(
-            self.is_building_for("osg-upcoming-el8", output),
-            "falsely building for el8-upcoming")
-
-    def test_koji_shell_old_upcoming2(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el7", "--repo", "upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(
-            self.is_building_for("osg-upcoming-el7", output),
-            "not building for el7-upcoming")
-        self.assertFalse(
-            self.is_building_for("osg-upcoming-el8", output),
-            "falsely building for el8-upcoming")
+            regex_in_list(r".*kojisession.build\([^,]+?, 'osg.+el[78]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
 
     def test_verify_correct_branch_svn(self):
         try:
-            _ = backtick_osg_build(self.kdr_lib + ["--upcoming", "--dry-run", opj(C.SVN_ROOT, DEVOPS, "koji")])
+            _ = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--dry-run", opj(C.SVN_ROOT, OSG_36, "osg-xrootd")])
         except CalledProcessError as err:
             out_list = err.output.split("\n")
             self.assertTrue(
@@ -452,8 +420,9 @@ class TestKoji(TestCase):
     def test_verify_correct_branch_git(self):
         try:
             # SCM URI format is 'git+https://host/.../repo.git?path#revision'
-            scm_uri = "git+%s?%s#%s" % (C.OSG_REMOTE, "koji", "devops")
-            _ = backtick_osg_build(self.kdr_lib + ["--upcoming", "--dry-run", scm_uri])
+            gitbranch = re.sub(r"^native/redhat/branches/", "", OSG_36)
+            scm_uri = "git+%s?%s#%s" % (C.OSG_REMOTE, "osg-xrootd", gitbranch)
+            _ = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--dry-run", scm_uri])
         except CalledProcessError as err:
             out_list = err.output.split("\n")
             self.assertTrue(
@@ -465,8 +434,8 @@ class TestKoji(TestCase):
 
 class TestKojiNewUpcoming(TestCase):
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(DEVOPS, "koji"),
-                                    "{2021-01-27}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
+                                    "{2023-07-21}")
 
     kdr_shell = ["koji", "--dry-run", "--koji-backend=shell"]
     kdr_lib = ["koji", "--dry-run", "--koji-backend=kojilib"]
@@ -511,8 +480,8 @@ class TestKojiNewUpcoming(TestCase):
 
 class TestKojiLong(TestCase):
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(DEVOPS, "koji"),
-                                    "{2021-01-27}")
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
+                                    "{2023-07-21}")
 
     def test_koji_build(self):
         checked_osg_build(["koji", "--el7", "--scratch", self.pkg_dir, "--wait"])

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -13,7 +13,7 @@ from unittest import makeSuite, TestCase
 
 import osgbuild.constants as C
 from osgbuild import srpm
-from osgbuild.test.common import OSG_36, regex_in_list, get_osg_build_path, go_to_temp_dir, common_setUp, \
+from osgbuild.test.common import OSG_36, regex_in_list, go_to_temp_dir, common_setUp, \
     backtick_osg_build, checked_osg_build
 from osgbuild.utils import (
     checked_backtick,
@@ -297,7 +297,8 @@ TestSuiteAll = TestSuiteShort  # backward compat
 
 if __name__ == '__main__':
     try:
-        errprintf("testing %s", get_osg_build_path())
+        import osgbuild.main
+        errprintf("testing %s", osgbuild.main)
         unittest.main()
     except CalledProcessError as e:
         errprintf("output: %s", e.output)

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -37,8 +37,8 @@ class TestLint(TestCase):
                 "unexpected number of packages checked")
             self.assertRegexpMatches(
                 out,
-                re.escape("rpmlint found problems with condor"),
-                "expected problems not found")
+                re.escape("rpmlint ok for condor"),
+                "rpmlint not ok for condor")
         except:
             errprintf("Problems found. Output:\n%s", out)
             raise

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -6,6 +6,7 @@
 import re
 import os
 from os.path import join as opj
+import sys
 import tarfile
 import unittest
 from unittest import makeSuite, TestCase
@@ -152,7 +153,7 @@ class TestFetch(TestCase):
     """Tests for fetch-sources"""
     @staticmethod
     def fetch_sources(pdir, nocheck=False):
-        cmd = ["python", "-m", "osgbuild.fetch_sources", pdir]
+        cmd = [sys.executable, "-m", "osgbuild.fetch_sources", pdir]
         if nocheck:
             cmd.append("--nocheck")
         checked_call(cmd)

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -155,7 +155,7 @@ class TestFetch(TestCase):
     def fetch_sources(pdir, nocheck=False):
         cmd = [sys.executable, "-m", "osgbuild.fetch_sources", pdir]
         if nocheck:
-            cmd.append("--nocheck")
+            cmd += ["--nocheck", "--quiet"]
         checked_call(cmd)
         return os.listdir(pdir)
 

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -3,91 +3,23 @@
 """
 # pylint: disable=C0103,R0904,W0614,C0111
 
-import atexit
-import grp
 import re
 import os
 from os.path import join as opj
-import pwd
-import shutil
-import tempfile
 import tarfile
 import unittest
 from unittest import makeSuite, TestCase
-import sys
 
 import osgbuild.constants as C
-from osgbuild import main
 from osgbuild import srpm
+from osgbuild.test.common import OSG_36, regex_in_list, get_osg_build_path, go_to_temp_dir, common_setUp, \
+    backtick_osg_build, checked_osg_build
 from osgbuild.utils import (
     checked_backtick,
     checked_call,
     CalledProcessError,
-    find_file,
     errprintf,
     unslurp)
-
-OSG_36 = "native/redhat/branches/osg-3.6"
-OSG_36_UPCOMING = "native/redhat/branches/3.6-upcoming"
-OSG_23_MAIN = "native/redhat/branches/23-main"
-OSG_23_UPCOMING = "native/redhat/branches/23-upcoming"
-
-initial_wd = os.getcwd()
-osg_build_path = find_file('osg-build', [initial_wd,
-                                         '/usr/bin'])
-
-if not osg_build_path:
-    errprintf("osg-build script not found!")
-    sys.exit(255)
-
-osg_build_command = [osg_build_path]
-
-
-def go_to_temp_dir():
-    working_dir = tempfile.mkdtemp(prefix="osg-build-test-")
-    atexit.register(shutil.rmtree, working_dir)
-    os.chdir(working_dir)
-    return working_dir
-
-
-def common_setUp(path, rev):
-    """Create a temporary directory, ensure it gets deleted on exit, cd to it,
-    and check out a specific revision of a path from our SVN.
-
-    """
-    working_dir = go_to_temp_dir()
-    svn_export(path, rev, os.path.basename(path))
-    return opj(working_dir, os.path.basename(path))
-
-
-def backtick_osg_build(cmd_args, *args, **kwargs):
-    kwargs['clocale'] = True
-    kwargs['err2out'] = True
-    return checked_backtick(osg_build_command + cmd_args, *args, **kwargs)
-
-
-def checked_osg_build(cmd_args, *args, **kwargs):
-    return checked_call(osg_build_command + cmd_args, *args, **kwargs)
-
-
-def svn_export(path, rev, destpath):
-    """Run svn export on a revision rev of path into destpath"""
-    try:
-        checked_backtick(
-            ["svn", "export", opj(C.SVN_ROOT, path) + "@" + rev, "-r", rev, destpath],
-            err2out=True)
-    except CalledProcessError as err:
-        errprintf("Error in svn export:\n%s", err.output)
-        raise
-
-
-def get_listing(directory):
-    return checked_backtick(
-            ["ls", directory]).split("\n")
-
-
-def regex_in_list(pattern, listing):
-    return [x for x in listing if re.match(pattern, x)]
 
 
 class TestLint(TestCase):
@@ -138,8 +70,8 @@ class TestPrebuild(TestCase):
         pkg_dir = common_setUp(opj(OSG_36, "xrootd"),
                                "{2023-07-21}")
         checked_osg_build(["prebuild", pkg_dir])
-        upstream_contents = get_listing(opj(pkg_dir, C.WD_UNPACKED))
-        final_contents = get_listing(opj(pkg_dir, C.WD_PREBUILD))
+        upstream_contents = os.listdir(opj(pkg_dir, C.WD_UNPACKED))
+        final_contents = os.listdir(opj(pkg_dir, C.WD_PREBUILD))
 
         self.assertTrue(
             "xrootd.spec" in upstream_contents,
@@ -161,7 +93,7 @@ class TestPrebuild(TestCase):
         pkg_osgonly_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
                                        "{2023-07-21}")
         checked_osg_build(["prebuild", pkg_osgonly_dir])
-        final_contents = get_listing(opj(pkg_osgonly_dir, C.WD_PREBUILD))
+        final_contents = os.listdir(opj(pkg_osgonly_dir, C.WD_PREBUILD))
 
         self.assertTrue(
             regex_in_list(
@@ -173,7 +105,7 @@ class TestPrebuild(TestCase):
         pkg_passthrough_dir = common_setUp(opj(OSG_36, "htgettoken"),
                                            "{2023-07-21}")
         checked_osg_build(["prebuild", pkg_passthrough_dir])
-        final_contents = get_listing(opj(pkg_passthrough_dir, C.WD_PREBUILD))
+        final_contents = os.listdir(opj(pkg_passthrough_dir, C.WD_PREBUILD))
 
         self.assertTrue(
             regex_in_list(
@@ -185,8 +117,8 @@ class TestPrebuild(TestCase):
         pkg_dir = common_setUp(opj(OSG_36, "xrootd-multiuser"),
                                "{2023-07-21}")
         out = backtick_osg_build(["prebuild", "--full-extract", pkg_dir])
-        ut_contents = get_listing(opj(pkg_dir, C.WD_UNPACKED_TARBALL))
-        tarball_contents = get_listing(opj(pkg_dir, C.WD_UNPACKED_TARBALL,
+        ut_contents = os.listdir(opj(pkg_dir, C.WD_UNPACKED_TARBALL))
+        tarball_contents = os.listdir(opj(pkg_dir, C.WD_UNPACKED_TARBALL,
                                            "xrootd-multiuser-2.1.3"))
 
         self.assertNotRegexpMatches(
@@ -224,7 +156,7 @@ class TestFetch(TestCase):
         if nocheck:
             cmd.append("--nocheck")
         checked_call(cmd)
-        return get_listing(pdir)
+        return os.listdir(pdir)
 
     def test_cache_fetch(self):
         common_setUp(opj(OSG_36, "xrootd"), "{2023-07-21}")
@@ -314,7 +246,7 @@ class TestFetch(TestCase):
         unslurp("upstream/github.source",
                 "type=github repo=opensciencegrid/cvmfs-config-osg tag=v2.1 hash=0000000000000000000000000000000000000000")
         checked_osg_build(["prebuild"])
-        contents = get_listing(C.WD_PREBUILD)
+        contents = os.listdir(C.WD_PREBUILD)
 
         self.assertTrue(
             regex_in_list(
@@ -323,183 +255,8 @@ class TestFetch(TestCase):
             "srpm not successfully built")
 
 
-
-class TestMock(TestCase):
-    """Tests for mock"""
-
-    def setUp(self):
-        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
-                                    "{2023-07-21}")
-
-    def check_for_mock_group(self):
-        username = pwd.getpwuid(os.getuid()).pw_name
-        try:
-            mock_group = grp.getgrnam('mock')
-        except KeyError:
-            errprintf("mock group not found")
-            return False
-        try:
-            if username in mock_group.gr_mem:
-                return True
-        except AttributeError:
-            pass
-        errprintf("%s not in mock group", username)
-        return False
-
-    def test_mock_koji_cfg(self):
-        if self.check_for_mock_group():
-            checked_osg_build(["mock", self.pkg_dir, "--el7", "--mock-config-from-koji=osg-3.6-el7-build"])
-
-
-class TestKoji(TestCase):
-    """Tests for koji"""
-
-    def setUp(self):
-        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
-                                    "{2023-07-21}")
-
-    kdr_shell = ["koji", "--dry-run", "--koji-backend=shell"]
-    kdr_lib = ["koji", "--dry-run", "--koji-backend=kojilib"]
-
-    build_target_lib_regex = r"^.*kojisession.build\([^,]+?, '%s'"
-    build_target_shell_regex = r"(osg-)?koji .*build %s"
-
-    def is_building_for(self, target, output):
-        return (re.search(self.build_target_lib_regex % target, output, re.MULTILINE) or
-                re.search(self.build_target_shell_regex % target, output, re.MULTILINE))
-
-    def test_koji_shell_args1(self):
-        output = backtick_osg_build(self.kdr_shell + ["--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg.+el7", output),
-                        "not building for el7")
-        self.assertTrue(self.is_building_for("osg.+el8", output),
-                        "not building for el8")
-        self.assertTrue(self.is_building_for("osg.+el9", output),
-                        "not building for el9")
-
-    def test_koji_shell_args2(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el7", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg.+el7", output),
-                        "not building for el7")
-        self.assertFalse(self.is_building_for("osg.+el8", output),
-                         "falsely building for el8")
-
-    def test_koji_shell_args3(self):
-        output = backtick_osg_build(self.kdr_shell + ["--ktt", "osg-el8", "--scratch", self.pkg_dir])
-        self.assertFalse(
-            self.is_building_for("osg.+el7", output),
-            "falsely building for el7")
-        self.assertTrue(
-            self.is_building_for("osg.+el8", output),
-            "not building for el8 for the right target")
-
-    def test_koji_shell_args4(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el7", "--koji-target", "osg-el7", "--koji-tag", "TARGET", "--scratch", self.pkg_dir])
-        out_list = output.split("\n")
-        self.assertFalse(
-            regex_in_list(r"Unable to determine redhat release", out_list),
-            "Bad error with --koji-tag=TARGET")
-
-    def test_koji_lib_args1(self):
-        output = backtick_osg_build(self.kdr_lib + ["--scratch", self.pkg_dir])
-        out_list = output.split("\n")
-        self.assertTrue(
-            regex_in_list(r".*kojisession.build\([^,]+?, 'osg.+el[78]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
-
-    def test_verify_correct_branch_svn(self):
-        try:
-            _ = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--dry-run", opj(C.SVN_ROOT, OSG_36, "osg-xrootd")])
-        except CalledProcessError as err:
-            out_list = err.output.split("\n")
-            self.assertTrue(
-                regex_in_list(r".*Forbidden to build from .+ branch into .+ target", out_list),
-                "did not detect attempt to build for wrong branch (wrong error message)")
-            return
-        self.fail("did not detect attempt to build for wrong branch (no error message)")
-
-    def test_verify_correct_branch_git(self):
-        try:
-            # SCM URI format is 'git+https://host/.../repo.git?path#revision'
-            gitbranch = re.sub(r"^native/redhat/branches/", "", OSG_36)
-            scm_uri = "git+%s?%s#%s" % (C.OSG_REMOTE, "osg-xrootd", gitbranch)
-            _ = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--dry-run", scm_uri])
-        except CalledProcessError as err:
-            out_list = err.output.split("\n")
-            self.assertTrue(
-                regex_in_list(r".*Forbidden to build from .+ branch into .+ target", out_list),
-                "did not detect attempt to build for wrong branch (wrong error message)")
-            return
-        self.fail("did not detect attempt to build for wrong branch (no error message)")
-
-
-class TestKojiNewUpcoming(TestCase):
-    def setUp(self):
-        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
-                                    "{2023-07-21}")
-
-    kdr_shell = ["koji", "--dry-run", "--koji-backend=shell"]
-    kdr_lib = ["koji", "--dry-run", "--koji-backend=kojilib"]
-
-    build_target_lib_regex = r"^.*kojisession.build\([^,]+?, '%s'"
-    build_target_shell_regex = r"(osg-)?koji .*build %s"
-
-    def is_building_for(self, target, output):
-        return (re.search(self.build_target_lib_regex % target, output, re.MULTILINE) or
-                re.search(self.build_target_shell_regex % target, output, re.MULTILINE))
-
-    def test_koji_lib_35upcoming(self):
-        output = backtick_osg_build(self.kdr_lib + ["--repo", "3.5-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el8", output))
-
-    def test_koji_lib_35upcoming_shorthand(self):
-        output = backtick_osg_build(self.kdr_lib + ["--3.5-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el8", output))
-
-    def test_koji_lib_36upcoming(self):
-        output = backtick_osg_build(self.kdr_lib + ["--repo", "3.6-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
-
-    def test_koji_lib_36upcoming_shorthand(self):
-        output = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
-
-    def test_koji_shell_35upcoming(self):
-        output = backtick_osg_build(self.kdr_shell + ["--repo", "3.5-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el8", output))
-
-    def test_koji_shell_36upcoming(self):
-        output = backtick_osg_build(self.kdr_shell + ["--repo", "3.6-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
-
-
-class TestKojiLong(TestCase):
-    def setUp(self):
-        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
-                                    "{2023-07-21}")
-
-    def test_koji_build(self):
-        checked_osg_build(["koji", "--el7", "--scratch", self.pkg_dir, "--wait"])
-
-
 class TestMisc(TestCase):
     """Other tests"""
-
-    def test_cmdline_scratch_svn(self):
-        buildopts = main.init(
-            ["osg-build", "koji", "--scratch", "."])[0]
-        self.assertFalse(buildopts['vcs'],
-                         "vcs not false for scratch build")
-
-        buildopts = main.init(
-            ["osg-build", "koji", "."])[0]
-        self.assertTrue(buildopts['vcs'],
-                        "vcs not true for non-scratch build")
 
     def test_rpmbuild_defines(self):
         buildopts_el = dict()
@@ -532,15 +289,14 @@ class TestMisc(TestCase):
             self.fail("osg-build --version failed")
 
 
-short_test_cases = (TestLint, TestRpmbuild, TestPrebuild, TestPrepare, TestFetch, TestMisc, TestKoji, TestKojiNewUpcoming)
+short_test_cases = (TestLint, TestRpmbuild, TestPrebuild, TestPrepare, TestFetch, TestMisc)
 TestSuiteShort = unittest.TestSuite()
 TestSuiteShort.addTests([makeSuite(t) for t in short_test_cases])
-# Make sure TestKojiLong comes first since it requires user interaction.
-TestSuiteAll = unittest.TestSuite((makeSuite(TestKojiLong), TestSuiteShort, makeSuite(TestMock)))
+TestSuiteAll = TestSuiteShort  # backward compat
 
 if __name__ == '__main__':
     try:
-        errprintf("testing %s", osg_build_path)
+        errprintf("testing %s", get_osg_build_path())
         unittest.main()
     except CalledProcessError as e:
         errprintf("output: %s", e.output)

--- a/osgbuild/test/test_osgbuild_koji.py
+++ b/osgbuild/test/test_osgbuild_koji.py
@@ -1,0 +1,200 @@
+import grp
+import os
+import re
+from os.path import join as opj
+import pwd
+import unittest
+from unittest import TestCase
+
+import osgbuild.constants as C
+from osgbuild import main
+from osgbuild.test.common import OSG_36, common_setUp, backtick_osg_build, regex_in_list, checked_osg_build, \
+    get_osg_build_path
+from osgbuild.utils import CalledProcessError, errprintf
+
+
+class TestKoji(TestCase):
+    """Tests for koji"""
+
+    def setUp(self):
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
+                                    "{2023-07-21}")
+
+    kdr_shell = ["koji", "--dry-run", "--koji-backend=shell"]
+    kdr_lib = ["koji", "--dry-run", "--koji-backend=kojilib"]
+
+    build_target_lib_regex = r"^.*kojisession.build\([^,]+?, '%s'"
+    build_target_shell_regex = r"(osg-)?koji .*build %s"
+
+    def is_building_for(self, target, output):
+        return (re.search(self.build_target_lib_regex % target, output, re.MULTILINE) or
+                re.search(self.build_target_shell_regex % target, output, re.MULTILINE))
+
+    def test_koji_shell_args1(self):
+        output = backtick_osg_build(self.kdr_shell + ["--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg.+el7", output),
+                        "not building for el7")
+        self.assertTrue(self.is_building_for("osg.+el8", output),
+                        "not building for el8")
+        self.assertTrue(self.is_building_for("osg.+el9", output),
+                        "not building for el9")
+
+    def test_koji_shell_args2(self):
+        output = backtick_osg_build(self.kdr_shell + ["--el7", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg.+el7", output),
+                        "not building for el7")
+        self.assertFalse(self.is_building_for("osg.+el8", output),
+                         "falsely building for el8")
+
+    def test_koji_shell_args3(self):
+        output = backtick_osg_build(self.kdr_shell + ["--ktt", "osg-el8", "--scratch", self.pkg_dir])
+        self.assertFalse(
+            self.is_building_for("osg.+el7", output),
+            "falsely building for el7")
+        self.assertTrue(
+            self.is_building_for("osg.+el8", output),
+            "not building for el8 for the right target")
+
+    def test_koji_shell_args4(self):
+        output = backtick_osg_build(self.kdr_shell + ["--el7", "--koji-target", "osg-el7", "--koji-tag", "TARGET", "--scratch", self.pkg_dir])
+        out_list = output.split("\n")
+        self.assertFalse(
+            regex_in_list(r"Unable to determine redhat release", out_list),
+            "Bad error with --koji-tag=TARGET")
+
+    def test_koji_lib_args1(self):
+        output = backtick_osg_build(self.kdr_lib + ["--scratch", self.pkg_dir])
+        out_list = output.split("\n")
+        self.assertTrue(
+            regex_in_list(r".*kojisession.build\([^,]+?, 'osg.+el[78]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
+
+    def test_verify_correct_branch_svn(self):
+        try:
+            _ = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--dry-run", opj(C.SVN_ROOT, OSG_36, "osg-xrootd")])
+        except CalledProcessError as err:
+            out_list = err.output.split("\n")
+            self.assertTrue(
+                regex_in_list(r".*Forbidden to build from .+ branch into .+ target", out_list),
+                "did not detect attempt to build for wrong branch (wrong error message)")
+            return
+        self.fail("did not detect attempt to build for wrong branch (no error message)")
+
+    def test_verify_correct_branch_git(self):
+        try:
+            # SCM URI format is 'git+https://host/.../repo.git?path#revision'
+            gitbranch = re.sub(r"^native/redhat/branches/", "", OSG_36)
+            scm_uri = "git+%s?%s#%s" % (C.OSG_REMOTE, "osg-xrootd", gitbranch)
+            _ = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--dry-run", scm_uri])
+        except CalledProcessError as err:
+            out_list = err.output.split("\n")
+            self.assertTrue(
+                regex_in_list(r".*Forbidden to build from .+ branch into .+ target", out_list),
+                "did not detect attempt to build for wrong branch (wrong error message)")
+            return
+        self.fail("did not detect attempt to build for wrong branch (no error message)")
+
+
+class TestKojiNewUpcoming(TestCase):
+    def setUp(self):
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
+                                    "{2023-07-21}")
+
+    kdr_shell = ["koji", "--dry-run", "--koji-backend=shell"]
+    kdr_lib = ["koji", "--dry-run", "--koji-backend=kojilib"]
+
+    build_target_lib_regex = r"^.*kojisession.build\([^,]+?, '%s'"
+    build_target_shell_regex = r"(osg-)?koji .*build %s"
+
+    def is_building_for(self, target, output):
+        return (re.search(self.build_target_lib_regex % target, output, re.MULTILINE) or
+                re.search(self.build_target_shell_regex % target, output, re.MULTILINE))
+
+    def test_koji_lib_35upcoming(self):
+        output = backtick_osg_build(self.kdr_lib + ["--repo", "3.5-upcoming", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el7", output))
+        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el8", output))
+
+    def test_koji_lib_35upcoming_shorthand(self):
+        output = backtick_osg_build(self.kdr_lib + ["--3.5-upcoming", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el7", output))
+        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el8", output))
+
+    def test_koji_lib_36upcoming(self):
+        output = backtick_osg_build(self.kdr_lib + ["--repo", "3.6-upcoming", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
+
+    def test_koji_lib_36upcoming_shorthand(self):
+        output = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
+
+    def test_koji_shell_35upcoming(self):
+        output = backtick_osg_build(self.kdr_shell + ["--repo", "3.5-upcoming", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el7", output))
+        self.assertTrue(self.is_building_for("osg-3.5-upcoming-el8", output))
+
+    def test_koji_shell_36upcoming(self):
+        output = backtick_osg_build(self.kdr_shell + ["--repo", "3.6-upcoming", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
+
+
+class TestKojiLong(TestCase):
+    def setUp(self):
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-xrootd"),
+                                    "{2023-07-21}")
+
+    def test_koji_build(self):
+        checked_osg_build(["koji", "--el7", "--scratch", self.pkg_dir, "--wait"])
+
+
+class TestKojiMisc(TestCase):
+    """Other Koji tests"""
+    def test_cmdline_scratch_svn(self):
+        buildopts = main.init(
+            ["osg-build", "koji", "--scratch", "."])[0]
+        self.assertFalse(buildopts['vcs'],
+                         "vcs not false for scratch build")
+
+        buildopts = main.init(
+            ["osg-build", "koji", "."])[0]
+        self.assertTrue(buildopts['vcs'],
+                        "vcs not true for non-scratch build")
+
+
+class TestMock(TestCase):
+    """Tests for mock"""
+
+    def setUp(self):
+        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
+                                    "{2023-07-21}")
+
+    @staticmethod
+    def check_for_mock_group():
+        username = pwd.getpwuid(os.getuid()).pw_name
+        try:
+            mock_group = grp.getgrnam('mock')
+        except KeyError:
+            errprintf("mock group not found")
+            return False
+        try:
+            if username in mock_group.gr_mem:
+                return True
+        except AttributeError:
+            pass
+        errprintf("%s not in mock group", username)
+        return False
+
+    def test_mock_koji_cfg(self):
+        if self.check_for_mock_group():
+            checked_osg_build(["mock", self.pkg_dir, "--el7", "--mock-config-from-koji=osg-3.6-el7-build"])
+
+
+if __name__ == '__main__':
+    try:
+        errprintf("testing %s", get_osg_build_path())
+        unittest.main()
+    except CalledProcessError as e:
+        errprintf("output: %s", e.output)
+        raise

--- a/osgbuild/test/test_osgbuild_koji.py
+++ b/osgbuild/test/test_osgbuild_koji.py
@@ -40,23 +40,23 @@ class TestKoji(TestCase):
                         "not building for el9")
 
     def test_koji_shell_args2(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el7", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg.+el7", output),
-                        "not building for el7")
+        output = backtick_osg_build(self.kdr_shell + ["--el9", "--scratch", self.pkg_dir])
+        self.assertTrue(self.is_building_for("osg.+el9", output),
+                        "not building for el9")
         self.assertFalse(self.is_building_for("osg.+el8", output),
                          "falsely building for el8")
 
     def test_koji_shell_args3(self):
         output = backtick_osg_build(self.kdr_shell + ["--ktt", "osg-el8", "--scratch", self.pkg_dir])
         self.assertFalse(
-            self.is_building_for("osg.+el7", output),
-            "falsely building for el7")
+            self.is_building_for("osg.+el9", output),
+            "falsely building for el9")
         self.assertTrue(
             self.is_building_for("osg.+el8", output),
             "not building for el8 for the right target")
 
     def test_koji_shell_args4(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el7", "--koji-target", "osg-el7", "--koji-tag", "TARGET", "--scratch", self.pkg_dir])
+        output = backtick_osg_build(self.kdr_shell + ["--el9", "--koji-target", "osg-el9", "--koji-tag", "TARGET", "--scratch", self.pkg_dir])
         out_list = output.split("\n")
         self.assertFalse(
             regex_in_list(r"Unable to determine redhat release", out_list),
@@ -66,7 +66,7 @@ class TestKoji(TestCase):
         output = backtick_osg_build(self.kdr_lib + ["--scratch", self.pkg_dir])
         out_list = output.split("\n")
         self.assertTrue(
-            regex_in_list(r".*kojisession.build\([^,]+?, 'osg.+el[78]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
+            regex_in_list(r".*kojisession.build\([^,]+?, 'osg.+el[89]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
 
     def test_verify_correct_branch_svn(self):
         try:
@@ -121,13 +121,13 @@ class TestKojiNewUpcoming(TestCase):
 
     def test_koji_lib_36upcoming(self):
         output = backtick_osg_build(self.kdr_lib + ["--repo", "3.6-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
         self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el9", output))
 
     def test_koji_lib_36upcoming_shorthand(self):
         output = backtick_osg_build(self.kdr_lib + ["--3.6-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
         self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el9", output))
 
     def test_koji_shell_35upcoming(self):
         output = backtick_osg_build(self.kdr_shell + ["--repo", "3.5-upcoming", "--scratch", self.pkg_dir])
@@ -136,8 +136,8 @@ class TestKojiNewUpcoming(TestCase):
 
     def test_koji_shell_36upcoming(self):
         output = backtick_osg_build(self.kdr_shell + ["--repo", "3.6-upcoming", "--scratch", self.pkg_dir])
-        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el7", output))
         self.assertTrue(self.is_building_for("osg-3.6-upcoming-el8", output))
+        self.assertTrue(self.is_building_for("osg-3.6-upcoming-el9", output))
 
 
 class TestKojiLong(TestCase):
@@ -146,7 +146,7 @@ class TestKojiLong(TestCase):
                                     "{2023-07-21}")
 
     def test_koji_build(self):
-        checked_osg_build(["koji", "--el7", "--scratch", self.pkg_dir, "--wait"])
+        checked_osg_build(["koji", "--el9", "--scratch", self.pkg_dir, "--wait"])
 
 
 class TestKojiMisc(TestCase):
@@ -188,7 +188,7 @@ class TestMock(TestCase):
 
     def test_mock_koji_cfg(self):
         if self.check_for_mock_group():
-            checked_osg_build(["mock", self.pkg_dir, "--el7", "--mock-config-from-koji=osg-3.6-el7-build"])
+            checked_osg_build(["mock", self.pkg_dir, "--el9", "--mock-config-from-koji=osg-3.6-el9-build"])
 
 
 if __name__ == '__main__':

--- a/osgbuild/test/test_osgbuild_koji.py
+++ b/osgbuild/test/test_osgbuild_koji.py
@@ -8,8 +8,7 @@ from unittest import TestCase
 
 import osgbuild.constants as C
 from osgbuild import main
-from osgbuild.test.common import OSG_23_MAIN, OSG_36, common_setUp, backtick_osg_build, regex_in_list, checked_osg_build, \
-    get_osg_build_path
+from osgbuild.test.common import OSG_23_MAIN, OSG_36, common_setUp, backtick_osg_build, regex_in_list, checked_osg_build
 from osgbuild.utils import CalledProcessError, errprintf
 
 
@@ -181,7 +180,7 @@ class TestMock(TestCase):
 
 if __name__ == '__main__':
     try:
-        errprintf("testing %s", get_osg_build_path())
+        errprintf("testing %s", main)
         unittest.main()
     except CalledProcessError as e:
         errprintf("output: %s", e.output)


### PR DESCRIPTION
Drop support for "trunk" and unversioned "upcoming", which are now "branches/osg-3.5" and "branches/3.5-upcoming".  Fix the tests that used trunk or upcoming, and add a bunch of other test fixes while I'm at it.

Tests using `koji` and `mock` were split off into a separate file, and the executable `osg-build-test` is now a script that calls the other tests.  koji tests are skipped if you don't have koji installed or your ~/.osg-koji is not set up.