### PR TITLE
Fix koji-blame (SOFTWARE-4532)

### DIFF
--- a/koji-blame
+++ b/koji-blame
@@ -40,8 +40,8 @@ def is_package(maybe_package):
         raise Error("koji list-pkgs returned unexpected result. Return: %d Output: %s" % (ret, out))
     return "No such entry" not in out
 
-def run_list_tag_history(item):
-    cmd = ["osg-koji", "list-tag-history"]
+def run_list_history(item):
+    cmd = ["osg-koji", "list-history"]
     if is_package(item):
         cmd += ["--package", item]
     elif is_build(item):
@@ -52,17 +52,15 @@ def run_list_tag_history(item):
         raise Error("%s is not a package, build or tag" % item)
     return utils.sbacktick(cmd)[0]
 
-def parse_history(lth_output, since=None, until=None):
-    # This is what a line of output from koji list-tag-history looks like:
-    # Fri May 30 11:45:59 2014: osg-configure-1.0.55-2.osg31.el6 tagged into osg-3.1-el6-development by Matyas Selmeci [still active]
-    pattern = re.compile(r"(?P<date>.+?): (?P<build>\S+) (?P<action>tagged into|untagged from) (?P<tag>\S+) by (?P<user>[^\[]+) \[still active\]")
+def parse_history(lh_output, since=None, until=None):
+    # This is what a line of output from koji list-history looks like:
+    # Fri May 30 11:45:59 2014 osg-configure-1.0.55-2.osg31.el6 tagged into osg-3.1-el6-development by Matyas Selmeci [still active]
+    pattern = re.compile(r"(?P<date>.+?20\d\d) (?P<build>\S+) (?P<action>tagged into|untagged from) (?P<tag>\S+) by (?P<user>[^\[]+) \[still active\]")
     parsed = []
-    for line in lth_output.split("\n"):
+    for line in lh_output.split("\n"):
         m = pattern.match(line)
         if m:
             user = m.group('user').rstrip()
-            if 'Edgar' in user and 'Fajardo' in user:
-                user = "Edgar Fajardo"
             user = re.sub(r" A?\d+$", "", user)
             date = strptime(m.group('date'), "%a %b %d %H:%M:%S %Y")
             if (since is None or since < date) and (until is None or date < until):
@@ -125,8 +123,8 @@ def main(argv):
     if not utils.which('osg-koji'):
         raise Error("osg-koji not found in $PATH")
     mode = detect_mode(args.koji_object)
-    lth_output = run_list_tag_history(args.koji_object)
-    print("\n".join(format_history_item(item, mode) for item in parse_history(lth_output,
+    lh_output = run_list_history(args.koji_object)
+    print("\n".join(format_history_item(item, mode) for item in parse_history(lh_output,
                                                                               since=args.since,
                                                                               until=args.until)))
 

--- a/koji-blame
+++ b/koji-blame
@@ -40,6 +40,7 @@ def is_package(maybe_package):
         raise Error("koji list-pkgs returned unexpected result. Return: %d Output: %s" % (ret, out))
     return "No such entry" not in out
 
+# TODO: koji list-history can take --before and --after arguments... try using those instead of re-implementing them
 def run_list_history(item):
     cmd = ["osg-koji", "list-history"]
     if is_package(item):

--- a/koji-blame
+++ b/koji-blame
@@ -28,14 +28,14 @@ def is_tag(maybe_tag):
     return maybe_tag in get_all_tags()
 
 def is_build(maybe_build):
-    out, ret = utils.sbacktick(["osg-koji", "buildinfo", maybe_build])
+    out, ret = utils.sbacktick(["osg-koji", "buildinfo", maybe_build], err2out=True)
     if maybe_build not in out:
         raise Error("koji buildinfo returned unexpected result. Return: %d Output: %s" % (ret, out))
     return "No such build" not in out
 
 def is_package(maybe_package):
     # Returns 1 if package not found
-    out, ret = utils.sbacktick(["osg-koji", "list-pkgs", "--package", maybe_package])
+    out, ret = utils.sbacktick(["osg-koji", "list-pkgs", "--package", maybe_package], err2out=True)
     if maybe_package not in out or (not 0 <= ret <= 1):
         raise Error("koji list-pkgs returned unexpected result. Return: %d Output: %s" % (ret, out))
     return "No such entry" not in out


### PR DESCRIPTION
What it says on the tin. I don't remember which version -- happened before 1.24 -- but koji replaced `list-tag-history` with just `list-history` and changed the output format. This updates koji-blame to parse the new format correctly. I didn't add any backward compat because older versions of koji aren't supported by the V2-branch anyway.

One thing I'd like to fix in the future is use `list-history`'s built-in date filtering instead of doing it ourselves but that's just a small performance thing.