### PR TITLE
osg-promote: validate signatures and try to sign packages

### DIFF
--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -4,6 +4,7 @@ to=osg-3.6-%s-contrib
 repotag=osg36
 dvers=el7 el8 el9
 extra_dvers=
+required_keys=OSG-2 OSG-4
 
 [route 3.6-prerelease]
 from=osg-3.6-%s-testing
@@ -11,6 +12,7 @@ to=osg-3.6-%s-prerelease
 repotag=osg36
 dvers=el7 el8 el9
 extra_dvers=
+required_keys=OSG-2 OSG-4
 
 [route 3.6-testing]
 from=osg-3.6-%s-development
@@ -18,6 +20,7 @@ to=osg-3.6-%s-testing
 repotag=osg36
 dvers=el7 el8 el9
 extra_dvers=
+required_keys=OSG-2 OSG-4
 
 [route hcc]
 from=hcc-%s-testing
@@ -25,6 +28,7 @@ to=hcc-%s-release
 repotag=hcc
 dvers=el7
 extra_dvers=el8 el9
+required_keys=HCC HCC-2
 
 [route 3.6-upcoming]
 from=osg-3.6-upcoming-%s-development
@@ -32,6 +36,7 @@ to=osg-3.6-upcoming-%s-testing
 repotag=osg36up
 dvers=el7 el8 el9
 extra_dvers=
+required_keys=OSG-2 OSG-4
 
 [route 3.6-upcoming-prerelease]
 from=osg-3.6-upcoming-%s-testing
@@ -39,6 +44,7 @@ to=osg-3.6-upcoming-%s-prerelease
 repotag=osg36up
 dvers=el7 el8 el9
 extra_dvers=
+required_keys=OSG-2 OSG-4
 
 [route 23-main]
 from=osg-23-main-%s-development
@@ -46,6 +52,7 @@ to=osg-23-main-%s-testing
 repotag=osg23
 dvers=el8 el9
 extra_dvers=
+required_keys=OSG-23-developer
 
 [route 23-main-prerelease]
 from=osg-23-main-%s-testing
@@ -53,6 +60,7 @@ to=osg-23-main-%s-prerelease
 repotag=osg23
 dvers=el8 el9
 extra_dvers=
+required_keys=OSG-23-developer
 
 [route 23-upcoming]
 from=osg-23-upcoming-%s-development
@@ -60,6 +68,7 @@ to=osg-23-upcoming-%s-testing
 repotag=osg23up
 dvers=el8 el9
 extra_dvers=
+required_keys=OSG-23-developer
 
 [route 23-upcoming-prerelease]
 from=osg-23-upcoming-%s-testing
@@ -67,6 +76,7 @@ to=osg-23-upcoming-%s-prerelease
 repotag=osg23up
 dvers=el8 el9
 extra_dvers=
+required_keys=OSG-23-developer
 
 [route 23-internal]
 from=osg-23-internal-%s-development
@@ -74,6 +84,7 @@ to=osg-23-internal-%s-release
 repotag=osg23int
 dvers=el8 el9
 extra_dvers=
+required_keys=OSG-23-developer
 
 [route devops-production]
 from=devops-%s-itb
@@ -81,6 +92,7 @@ to=devops-%s-production
 repotag=osgdevops
 dvers=el7 el8 el9
 extra_dvers=
+required_keys=OSG-2 OSG-4
 
 [aliases]
 3.6-rfr=3.6-prerelease

--- a/osgbuild/promoter.py
+++ b/osgbuild/promoter.py
@@ -231,7 +231,6 @@ class Configuration(IniConfiguration):
         return dvers
 
 
-
 #
 # Utility functions
 #

--- a/osgbuild/promoter.py
+++ b/osgbuild/promoter.py
@@ -5,11 +5,12 @@ import logging
 import os
 import re
 import sys
-from typing import List, Dict
+from typing import List, Optional, Dict, Set, Tuple
 
 from osgbuild.kojiinter import KojiHelper
 from . import constants
 from . import error
+from . import osg_sign
 from . import utils
 from .osg_sign import SigningKey, SigningKeysConfig
 from .utils import comma_join, printf, print_table, IniConfiguration, split_nvr

--- a/osgbuild/promoter.py
+++ b/osgbuild/promoter.py
@@ -147,7 +147,7 @@ class Configuration(IniConfiguration):
         """
         routes = {}
         for sec in route_sections:
-            routename = sec.split(None, 1)[1]
+            routename = sec.split(maxsplit=1)[1]
             from_tag_hint = self.config_safe_get(sec, 'from')
             to_tag_hint = self.config_safe_get(sec, 'to')
             repotag = self.config_safe_get(sec, 'repotag')

--- a/osgbuild/promoter.py
+++ b/osgbuild/promoter.py
@@ -83,7 +83,7 @@ class Build(object):
 class Reject(object):
     REASON_DISTINCT_ACROSS_DISTS = "%(pkg_or_build)s: Matching build versions distinct across dist tags"
     REASON_NOMATCHING_FOR_DIST = "%(pkg_or_build)s: No matching build for dist %(dist)s"
-    REASON_MISSING_REQUIRED_SIGNATURE = "%(pkg_or_build)s: RPM %(rpm)s missing required signature (%(signing_keys)s)"
+    REASON_MISSING_REQUIRED_SIGNATURE = "%(pkg_or_build)s: RPM(s) %(rpms)s missing required signature (%(signing_keys)s)"
 
     def __init__(self, pkg_or_build, reason, details=None):
         # type: (str, str, Optional[Dict]) -> None
@@ -94,7 +94,7 @@ class Reject(object):
         self.details = {
             'pkg_or_build': self.pkg_or_build,
             'dist': "?",
-            'rpm': "?",
+            'rpms': "?",
             'signing_keys': [],
         }
         self.details.update(details)

--- a/osgbuild/promoter.py
+++ b/osgbuild/promoter.py
@@ -6,17 +6,17 @@ import os
 import re
 import sys
 import configparser
+from typing import List
 
 from osgbuild.kojiinter import KojiHelper
 from . import constants
 from . import error
 from . import utils
+from .osg_sign import SigningKey
 from .utils import comma_join, printf, print_table, split_nvr
 from optparse import OptionParser
 
 log = logging.getLogger(__name__)
-from collections import namedtuple
-
 DEFAULT_ROUTE = 'testing'
 INIFILE = 'promoter.ini'
 
@@ -29,7 +29,21 @@ class KojiTagsAreMessedUp(Exception):
     """
 
 
-Route = namedtuple('Route', ['from_tag_hint', 'to_tag_hint', 'repotag', 'dvers', 'extra_dvers'])
+class Route(object):
+    """Information about a promotion route"""
+    def __init__(self, from_tag_hint, to_tag_hint, repotag, dvers, extra_dvers, required_keys=None):
+        # type: (str, str, str, List[str], List[str], List[SigningKey]) -> None
+        self.from_tag_hint = from_tag_hint
+        self.to_tag_hint = to_tag_hint
+        self.repotag = repotag
+        self.dvers = dvers
+        self.extra_dvers = extra_dvers
+        self.required_keys = required_keys or []
+
+    def required_keys_for_dver(self, dver):
+        # type: (str) -> List[SigningKey]
+        """The key ids of the keys required for the given dver for this route"""
+        return [x for x in self.required_keys if dver in x.dvers]
 
 
 class Build(object):

--- a/osgbuild/test/test_osgpromote.py
+++ b/osgbuild/test/test_osgpromote.py
@@ -14,9 +14,16 @@ from osgbuild import promoter
 from osgbuild import osg_sign
 from osgbuild import constants
 from osgbuild import utils
+from osgbuild.kojiinter import RpmKeyidsPair
 
 log = logging.getLogger('promoter')
 log.setLevel(logging.ERROR)
+
+
+KEY_OSG_2 = "96d2b90f"
+KEY_OSG_4 = "1887c61a"
+KEY_OSG_23_developer = "92897c00"
+
 
 TAGS = ['condor-el6',
         'condor-el7',
@@ -252,10 +259,12 @@ class FakeKojiHelper(osgbuild.kojiinter.KojiHelper):
             'osg-23-upcoming-el9-development': [
                 {'nvr': 'goodpkg-2000-1.osg23up.el9', 'latest': True},
                 {'nvr': 'reject-distinct-repos-1-1.osg23up.el9', 'latest': True},
+                {'nvr': 'reject-invalid-key-1-1.osg23up.el9', 'latest': True},
             ],
             'osg-23-upcoming-el8-development': [
                 {'nvr': 'goodpkg-2000-1.osg23up.el8', 'latest': True},
                 {'nvr': 'reject-distinct-repos-1-1.osg23up.el8', 'latest': True},
+                {'nvr': 'reject-invalid-key-1-1.osg23up.el8', 'latest': True},
             ],
             'osg-3.6-upcoming-el7-development': [
                 {'nvr': 'goodpkg-2000-1.osg36up.el7', 'latest': True},
@@ -269,6 +278,21 @@ class FakeKojiHelper(osgbuild.kojiinter.KojiHelper):
                 {'nvr': 'goodpkg-2000-1.osg36up.el9', 'latest': True},
                 {'nvr': 'reject-distinct-repos-1-1.osg36up.el9', 'latest': True},
             ],
+    }
+
+    rpms_and_keyids_by_nvr = {
+        'goodpkg-2000-1.osg36up.el9':
+            [RpmKeyidsPair('goodpkg-2000-1.osg36up.el9.x86_64.rpm', {KEY_OSG_4})],
+        'goodpkg-2000-1.osg36up.el8':
+            [RpmKeyidsPair('goodpkg-2000-1.osg36up.el8.x86_64.rpm', {KEY_OSG_2})],
+        'goodpkg-2000-1.osg23up.el9':
+            [RpmKeyidsPair('goodpkg-2000-1.osg23up.el9.x86_64.rpm', {KEY_OSG_23_developer})],
+        'goodpkg-2000-1.osg23up.el8':
+            [RpmKeyidsPair('goodpkg-2000-1.osg23up.el8.x86_64.rpm', {KEY_OSG_23_developer})],
+        'reject-invalid-key-1-1.osg23up.el9':
+            [RpmKeyidsPair('reject-invalid-key-1-1.osg23up.el9.x86_64.rpm', {KEY_OSG_2})],
+        'reject-invalid-key-1-1.osg23up.el8':
+            [RpmKeyidsPair('reject-invalid-key-1-1.osg23up.el8.x86_64.rpm', {KEY_OSG_4})],
     }
 
     want_success = True
@@ -301,6 +325,9 @@ class FakeKojiHelper(osgbuild.kojiinter.KojiHelper):
 
     def koji_get_build(self, build_nvr):
         return {'id': 319}
+
+    def get_rpms_and_keyids_in_build(self, build_nvr):
+        return self.rpms_and_keyids_by_nvr.get(build_nvr, [])
 
     def tag_build(self, tag, build, force=False):
         self.newly_tagged_packages.append(build)
@@ -403,42 +430,70 @@ class TestPromoter(unittest.TestCase):
                                                        dvers=self.route_23upcoming.dvers)
         self.multi_routes = [self.configuration.routes['23-main'], self.configuration.routes['3.6-testing']]
 
-
     def _make_promoter(self, routes, dvers):
         pairs = [(route, set(dvers)) for route in routes]
-        return promoter.Promoter(self.kojihelper, pairs)
+        signing_keys = self.configuration.signing_keys_by_name
+        return promoter.Promoter(self.kojihelper, pairs, signing_keys)
+
+    @staticmethod
+    def _tagged_nvrs(promoter_obj, route, dver):
+        return [x.nvr for x in promoter_obj.tag_pkg_args[route.to_tag_hint % dver]]
 
     def test_add_promotion(self):
-        self.promoter_36testing.add_promotion('goodpkg')
+        self.promoter_36testing.add_promotion('goodpkg', ignore_signatures=True)
         for dver in self.route_36testing.dvers:
             self.assertIn(
                 'goodpkg-2000-1.osg36.%s' % dver,
                 [x.nvr for x in self.promoter_36testing.tag_pkg_args[self.route_36testing.to_tag_hint % dver]])
 
     def test_add_promotion_with_nvr(self):
-        self.promoter_36testing.add_promotion('goodpkg-2000-1.osg36.el8')
+        self.promoter_36testing.add_promotion('goodpkg-2000-1.osg36.el8', ignore_signatures=True)
         for dver in self.route_36testing.dvers:
             self.assertIn(
                 'goodpkg-2000-1.osg36.%s' % dver,
                 [x.nvr for x in self.promoter_36testing.tag_pkg_args[self.route_36testing.to_tag_hint % dver]])
 
     def test_add_promotion_with_nvr_no_dist(self):
-        self.promoter_36testing.add_promotion('goodpkg-2000-1')
+        self.promoter_36testing.add_promotion('goodpkg-2000-1', ignore_signatures=True)
         for dver in self.route_36testing.dvers:
             self.assertIn(
                 'goodpkg-2000-1.osg36.%s' % dver,
                 [x.nvr for x in self.promoter_36testing.tag_pkg_args[self.route_36testing.to_tag_hint % dver]])
 
+    def test_add_promotion_with_signature_check(self):
+        build_base = 'goodpkg-2000-1'
+        for route, prom in [(self.route_36upcoming, self.promoter_36upcoming),
+                            (self.route_23upcoming, self.promoter_23upcoming)]:
+            repotag = route.repotag
+            prom.add_promotion(build_base, ignore_signatures=False)
+            self.assertEqual(prom.rejects, [])
+            for dver in route.dvers:
+                build = '%s.%s.%s' % (build_base, repotag, dver)
+                self.assertIn(build, self._tagged_nvrs(prom, route, dver))
+
+    def test_reject_signature(self):
+        build_base = 'reject-invalid-key-1-1'
+        route = self.route_23upcoming
+        repotag = route.repotag
+        self.promoter_23upcoming.add_promotion(build_base, ignore_signatures=False)
+        self.assertNotEqual(self.promoter_23upcoming.rejects, [])
+        self.assertTrue(all(
+            x.reason == promoter.Reject.REASON_MISSING_REQUIRED_SIGNATURE for x in self.promoter_23upcoming.rejects))
+        for dver in route.dvers:
+            build = '%s.%s.%s' % (build_base, repotag, dver)
+            self.assertNotIn(build,
+                             self._tagged_nvrs(self.promoter_23upcoming, route, dver))
+
     def test_reject_add(self):
-        self.promoter_36testing.add_promotion('goodpkg')
-        self.promoter_36testing.add_promotion('reject-distinct-dvers')
+        self.promoter_36testing.add_promotion('goodpkg', ignore_signatures=True)
+        self.promoter_36testing.add_promotion('reject-distinct-dvers', ignore_signatures=True)
         self.assertNotIn(
             'reject-distinct-dvers-1-1.osg36.el8',
             [x.nvr for x in self.promoter_36testing.tag_pkg_args[self.route_36testing.to_tag_hint % 'el8']])
 
     def test_reject_add_with_ignore(self):
-        self.promoter_36testing.add_promotion('goodpkg')
-        self.promoter_36testing.add_promotion('reject-distinct-dvers', ignore_rejects=True)
+        self.promoter_36testing.add_promotion('goodpkg', ignore_signatures=True)
+        self.promoter_36testing.add_promotion('reject-distinct-dvers', ignore_rejects=True, ignore_signatures=True)
         self.assertIn(
             'reject-distinct-dvers-1-1.osg36.el8',
             [x.nvr for x in self.promoter_36testing.tag_pkg_args[self.route_36testing.to_tag_hint % 'el8']])
@@ -447,7 +502,7 @@ class TestPromoter(unittest.TestCase):
             [x.nvr for x in self.promoter_36testing.tag_pkg_args[self.route_36testing.to_tag_hint % 'el7']])
 
     def test_new_reject(self):
-        self.promoter_36testing.add_promotion('reject-distinct-dvers')
+        self.promoter_36testing.add_promotion('reject-distinct-dvers', ignore_signatures=True)
         rejs = self.promoter_36testing.rejects
         self.assertEqual(1, len(rejs))
         self.assertEqual('reject-distinct-dvers', rejs[0].pkg_or_build)
@@ -456,7 +511,7 @@ class TestPromoter(unittest.TestCase):
     def test_multi_promote(self):
         prom = self._make_promoter(self.multi_routes,
                                    dvers=self.route_23main.dvers)
-        prom.add_promotion('goodpkg-2000-1')
+        prom.add_promotion('goodpkg-2000-1', ignore_signatures=True)
         for dver in self.route_23main.dvers:
             for osgver, repo in [('23', '23-main'), ('3.6', '3.6')]:
                 tag = 'osg-%s-%s-testing' % (repo, dver)
@@ -468,13 +523,13 @@ class TestPromoter(unittest.TestCase):
 
     def test_cross_dist_reject(self):
         prom = self._make_promoter(self.multi_routes, ['el8'])
-        prom.add_promotion('reject-distinct-repos')
+        prom.add_promotion('reject-distinct-repos', ignore_signatures=True)
         rejs = prom.rejects
         self.assertEqual(1, len(rejs))
         self.assertEqual(promoter.Reject.REASON_DISTINCT_ACROSS_DISTS, rejs[0].reason)
 
     def test_do_promotions(self):
-        self.promoter_36testing.add_promotion('goodpkg')
+        self.promoter_36testing.add_promotion('goodpkg', ignore_signatures=True)
         promoted_builds = self.promoter_36testing.do_promotions()
         self.assertEqual(3, len(self.kojihelper.newly_tagged_packages))
         for dver in self.route_36testing.dvers:
@@ -489,7 +544,7 @@ class TestPromoter(unittest.TestCase):
     def test_do_multi_promotions(self):
         prom = self._make_promoter(self.multi_routes,
                                    dvers=self.route_23main.dvers)
-        prom.add_promotion('goodpkg-2000-1')
+        prom.add_promotion('goodpkg-2000-1', ignore_signatures=True)
         promoted_builds = prom.do_promotions()
         self.assertEqual(4, len(self.kojihelper.newly_tagged_packages))
         for osgver, repo in [('23', '23-main'), ('3.6', '3.6')]:
@@ -517,7 +572,7 @@ class TestPromoter(unittest.TestCase):
         if real_promotions:
             prom = self._make_promoter(self.multi_routes,
                                        dvers=self.route_23main.dvers)
-            prom.add_promotion('goodpkg-2000-1')
+            prom.add_promotion('goodpkg-2000-1', ignore_signatures=True)
             promoted_builds = prom.do_promotions()
         expected_lines = [
             "*Promotions*",
@@ -547,7 +602,7 @@ class TestPromoter(unittest.TestCase):
         if real_promotions:
             prom = self._make_promoter(self.multi_routes,
                                        dvers=self.route_23main.dvers)
-            prom.add_promotion('goodpkg-2000-1')
+            prom.add_promotion('goodpkg-2000-1', ignore_signatures=True)
             promoted_builds = prom.do_promotions()
         expected_lines = [
             "**Promotions**",

--- a/osgbuild/test/test_osgpromote.py
+++ b/osgbuild/test/test_osgpromote.py
@@ -11,10 +11,9 @@ import osgbuild.kojiinter
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../.."))
 
 from osgbuild import promoter
+from osgbuild import osg_sign
 from osgbuild import constants
 from osgbuild import utils
-
-INIFILE = "promoter.ini"
 
 log = logging.getLogger('promoter')
 log.setLevel(logging.ERROR)
@@ -337,9 +336,13 @@ class TestUtil(unittest.TestCase):
 
 
 def _config():
-    configuration = promoter.Configuration()
-    configuration.load_inifile(INIFILE)
-    configuration.load_inifile("../osgbuild/test/promoter_extra.ini")
+    signing_keys_ini = utils.find_file(constants.SIGNING_KEYS_INI,
+                                       strict=True)
+    signing_keys_config = osg_sign.SigningKeysConfig(signing_keys_ini)
+    configuration = promoter.Configuration([
+        utils.find_file(constants.PROMOTER_INI),
+        "../osgbuild/test/promoter_extra.ini"
+    ], signing_keys_config)
     return configuration
 
 


### PR DESCRIPTION
SOFTWARE-5637

This adds config to promoter.ini listing the required key(s) for each promotion route, and code to promoter.py to check signatures and, if necessary, run osg-sign to sign RPMs.

There was some cleanup work along the way. I promoter.Configuration is now a subclass of utils.IniConfiguration; the ini files are immediately loaded when creating the object, you don't have to call load_inifile() separately. You need to have created an osg_sign.SigningKeysConfig before creating the Configuration object. Parsing has been split up into multiple methods to make the flow cleaner. If there are multiple errors in a config section, they will all be reported instead of exiting at the first one.

The Route class was changed from a namedtuple to a regular object so I could add a method to filter the required keys for that route down to the ones that are usable for the distro version we're doing a specific promotion for.

An invalid signature is a type of rejection so the Reject class was reworked to allow the new rejection type, which has its own set of details.

Promoter.get_builds() was changed to Promoter.get_dver_build_pairs() - this changed the return type from a dict that we treated like a list of pairs to just a list of pairs.

Like the other osg-promote checks, signature validation is on by default; you can add `--ignore-signatures` on the command line to turn it off for a run.  Before rejecting a promotion due to an invalid signature, osg-promote may try to sign it if you're running it interactively and you have the key.  This could use some work -- for example we should bail out early on certain errors like not having permissions to sign -- but it gets the job done.