### PR TITLE
Add support for "CHTC" repos

### DIFF
--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -100,7 +100,7 @@ to=chtc-%s-testing
 repotag=chtc
 dvers=el9
 extra_dvers=el8
-;required_keys=CHTC
+required_keys=CHTC
 
 [route chtc-release]
 from=chtc-%s-testing
@@ -108,7 +108,7 @@ to=chtc-%s-release
 repotag=chtc
 dvers=el9
 extra_dvers=el8
-;required_keys=CHTC
+required_keys=CHTC
 
 [aliases]
 3.6-rfr=3.6-prerelease

--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -98,16 +98,16 @@ required_keys=OSG-2 OSG-4
 from=chtc-%s-development
 to=chtc-%s-testing
 repotag=chtc
-dvers=el8 el9
-extra_dvers=
+dvers=el9
+extra_dvers=el8
 ;required_keys=CHTC
 
 [route chtc-release]
 from=chtc-%s-testing
 to=chtc-%s-release
 repotag=chtc
-dvers=el8 el9
-extra_dvers=
+dvers=el9
+extra_dvers=el8
 ;required_keys=CHTC
 
 [aliases]

--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -94,6 +94,22 @@ dvers=el7 el8 el9
 extra_dvers=
 required_keys=OSG-2 OSG-4
 
+[route chtc-testing]
+from=chtc-%s-development
+to=chtc-%s-testing
+repotag=chtc
+dvers=el8 el9
+extra_dvers=
+;required_keys=CHTC
+
+[route chtc-release]
+from=chtc-%s-testing
+to=chtc-%s-release
+repotag=chtc
+dvers=el8 el9
+extra_dvers=
+;required_keys=CHTC
+
 [aliases]
 3.6-rfr=3.6-prerelease
 3.6-up=3.6-upcoming

--- a/data/signing_keys.ini
+++ b/data/signing_keys.ini
@@ -26,7 +26,7 @@ keyid=92897c00
 dvers=el8 el9
 digest_algo = sha256
 
-;[key CHTC]
-;keyid=
-;dvers=el8 el9
-;digest_algo = sha256
+[key CHTC]
+keyid=30ad7213
+dvers=el8 el9
+digest_algo = sha256

--- a/data/signing_keys.ini
+++ b/data/signing_keys.ini
@@ -25,3 +25,8 @@ digest_algo = sha256
 keyid=92897c00
 dvers=el8 el9
 digest_algo = sha256
+
+;[key CHTC]
+;keyid=
+;dvers=el8 el9
+;digest_algo = sha256

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -37,6 +37,7 @@ except (ImportError, AttributeError):
 SVN_ROOT = "https://vdt.cs.wisc.edu/svn"
 SVN_REDHAT_PATH = "/native/redhat"
 
+# fmt: off
 SVN_RESTRICTED_BRANCHES = {
     r'^branches/(?P<osgver>[0-9.]+)-upcoming$': 'upcoming',
     r'^branches/osg-internal$'             : 'oldinternal',
@@ -53,6 +54,7 @@ KOJI_RESTRICTED_TARGETS = {
     r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'  : 'versioned',
     r'^(?P<osgver>[0-9.]+)-main-(el\d+)$'  : 'versioned',
     r'^(?P<osgver>[0-9.]+)-internal-(el\d+)$' : 'internal',
+    r'^chtc-(el\d+)$'                      : 'chtc',
 }
 GIT_RESTRICTED_BRANCHES = {
     r'^(\w*/)?(?P<osgver>[0-9.]+)-upcoming$': 'upcoming',
@@ -62,19 +64,25 @@ GIT_RESTRICTED_BRANCHES = {
     r'^(\w*/)?(?P<osgver>[0-9.]+)-main$'   : 'versioned',
     r'^(\w*/)?(?P<osgver>[0-9.]+)-internal$' : 'internal',
 }
+# fmt: on
 
 OSG_REMOTE = 'https://github.com/opensciencegrid/Software-Redhat.git'
 OSG_AUTH_REMOTE = 'git@github.com:opensciencegrid/Software-Redhat.git'
 HCC_REMOTE = 'https://github.com/unlhcc/hcc-packaging.git'
 HCC_AUTH_REMOTE = 'git@github.com:unlhcc/hcc-packaging.git'
+CHTC_REMOTE = 'https://github.com/CHTC/packaging.git'
+CHTC_AUTH_REMOTE = 'git@github.com:CHTC/packaging.git'
 
 KNOWN_GIT_REMOTES = [HCC_REMOTE,
                      HCC_AUTH_REMOTE,
                      OSG_REMOTE,
-                     OSG_AUTH_REMOTE]
+                     OSG_AUTH_REMOTE,
+                     CHTC_REMOTE,
+                     CHTC_AUTH_REMOTE]
 # Map the authenticated URL to an anonymous checkout URL.
 GIT_REMOTE_MAPS = {HCC_AUTH_REMOTE: HCC_REMOTE,
-                   OSG_AUTH_REMOTE: OSG_REMOTE}
+                   OSG_AUTH_REMOTE: OSG_REMOTE,
+                   CHTC_AUTH_REMOTE: CHTC_REMOTE}
 
 DEFAULT_BUILDOPTS_COMMON = {
     'autoclean': True,
@@ -137,6 +145,7 @@ REPO_HINTS_STATIC = {
     'internal': {'target': 'osg-%(dver)s-internal', 'tag': 'osg-%(dver)s'},
     'devops': {'target': 'devops-%(dver)s', 'tag': 'osg-%(dver)s'},
     'hcc': {'target': 'hcc-%(dver)s', 'tag': 'hcc-%(dver)s'},
+    'chtc': {'target': 'chtc-%(dver)s', 'tag': 'chtc-%(dver)s'},
 }
 
 BUGREPORT_EMAIL = "help@osg-htc.org"

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -132,6 +132,7 @@ DEFAULT_DVERS_BY_REPO = {
     '23-internal': ['el8', 'el9'],
     'internal': ['el7'],
     'devops': ['el7', 'el8', 'el9'],
+    'chtc': ['el8', 'el9'],
 }
 assert FALLBACK_DVER in DVERS
 for d in DEFAULT_DVERS:

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -132,7 +132,7 @@ DEFAULT_DVERS_BY_REPO = {
     '23-internal': ['el8', 'el9'],
     'internal': ['el7'],
     'devops': ['el7', 'el8', 'el9'],
-    'chtc': ['el8', 'el9'],
+    'chtc': ['el9'],
 }
 assert FALLBACK_DVER in DVERS
 for d in DEFAULT_DVERS:

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -179,6 +179,8 @@ def get_known_remote(package_dir):
             continue
         if info[1] in constants.KNOWN_GIT_REMOTES:
             return info[0], info[1]
+        elif info[1] + ".git" in constants.KNOWN_GIT_REMOTES:
+            return info[0], info[1] + ".git"
     raise GitError("OSG remote not found for directory %s; are remotes configurated correctly?" % package_dir)
 
 

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -40,6 +40,18 @@ def is_git(package_dir):
     return True
 
 
+def _normalize_remote(remote_url):
+    """Normalize the URL of the given Git repo which means:
+
+    - add the ".git" at the end if necessary
+    - correct the capitalization of Software-Redhat
+    """
+    if not remote_url.endswith(".git"):
+        remote_url = remote_url + ".git"
+    remote_url = re.sub(r"software-redhat", "Software-Redhat", remote_url, flags=re.IGNORECASE)
+    return remote_url
+
+
 def parse_git_url(git_url):
     """Parse a git URL of the type recognized by Koji, which looks like
     `git+REPO?DIRECTORY#BRANCH`
@@ -54,8 +66,7 @@ def parse_git_url(git_url):
         if not (scheme and netloc and path and query):
             return None, None, None
         scheme = scheme.rsplit("+")[-1]  # git+https -> https
-        if not path.endswith(".git"):
-            path = path + ".git"
+        path = _normalize_remote(path)
         repo = "{scheme}://{netloc}{path}".format(**locals())
         directory = query
         branch = fragment or "HEAD"
@@ -165,7 +176,9 @@ def get_branch(package_dir):
 
 def get_known_remote(package_dir):
     """Return the first remote in the current directory's list of remotes which
-       is on osg-build's configured whitelist of remotes."""
+       is on osg-build's configured whitelist of remotes,
+       as a (name, normalized url) tuple.
+       """
     top_dir = os.path.split(os.path.abspath(package_dir))[0]
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "remote", "-v"]
     out, err = utils.sbacktick(command, err2out=True)
@@ -177,11 +190,11 @@ def get_known_remote(package_dir):
             continue
         if info[2] != '(fetch)':
             continue
-        if info[1] in constants.KNOWN_GIT_REMOTES:
-            return info[0], info[1]
-        elif info[1] + ".git" in constants.KNOWN_GIT_REMOTES:
-            return info[0], info[1] + ".git"
-    raise GitError("OSG remote not found for directory %s; are remotes configurated correctly?" % package_dir)
+        remote_name = info[0]
+        remote_url = _normalize_remote(info[1])
+        if remote_url in constants.KNOWN_GIT_REMOTES:
+            return remote_name, remote_url
+    raise GitError("Known remote not found for directory %s; are remotes configurated correctly?" % package_dir)
 
 
 def get_fetch_url(package_dir, remote):
@@ -198,14 +211,16 @@ def get_fetch_url(package_dir, remote):
             continue
         if info[2] != '(fetch)':
             continue
-        if info[0] == remote:
-            return constants.GIT_REMOTE_MAPS.setdefault(info[1], info[1])
+        dir_remote_name = info[0]
+        dir_remote_url = _normalize_remote(info[1])
+        if dir_remote_name == remote:
+            return constants.GIT_REMOTE_MAPS.setdefault(dir_remote_url, dir_remote_url)
 
     raise GitError("Remote URL not found for remote %s in directory %s; are remotes " \
         "configured correctly?" % (remote, package_dir))
 
 def get_current_branch_remote(package_dir):
-    """Return the configured remote for the current branch."""
+    """Return the configured remote name for the current branch."""
     branch = get_branch(package_dir)
 
     top_dir = os.path.split(os.path.abspath(package_dir))[0]
@@ -480,6 +495,6 @@ def koji(package_dir, koji_obj, buildopts):
     if not buildopts.get('scratch'):
         koji_obj.add_pkg(package_name)
 
-    return koji_obj.build_git(remote,
+    return koji_obj.build_git(_normalize_remote(remote),
                               rev,
                               package_name)

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -410,40 +410,40 @@ def verify_correct_branch(package_dir, buildopts):
             raise GitError("Forbidden to build from %s branch into %s target" % (branch, target))
 
 
-def _do_target_remote_checks(target, remote, branch):
-        if target.startswith("hcc-"):
-            if "master" not in branch:
-                raise Error("""\
+def _do_target_remote_checks_hcc(remote, branch):
+    if remote not in [constants.HCC_REMOTE, constants.HCC_AUTH_REMOTE]:
+        raise Error("""\
+Error: You must build into the HCC repo from a HCC git checkout.
+You must switch git repos or build targets.""")
+
+    if "master" not in branch:
+        raise Error("""\
 Error: Incorrect branch for koji build
 Only allowed to build into the HCC repo from the
 master branch!  You must switch branches.""")
-            if remote not in [constants.HCC_REMOTE, constants.HCC_AUTH_REMOTE]:
-                raise Error("""\
-Error: You must build into the HCC repo when building from
-a HCC git checkout.  You must switch git repos or build targets.""")
-        elif re.search(r"osg(?:-\d+\.\d+)?-upcoming-el\d+$", target):
-            if remote not in [constants.OSG_REMOTE, constants.OSG_AUTH_REMOTE]:
-                raise Error("""\
-Error: You may not build into the OSG repo when building from
-a non-OSG target.  You must switch git repos or build targets.
-Try adding "--repo=hcc" to the command line.""")
-            if "master" in branch:
-                raise Error("""\
-Error: Incorrect branch for koji build
-Not allowed to build into the upcoming targets from
-master branch!  You must switch branches or build targets.""")
-        elif "osg" in target:
-            if remote not in [constants.OSG_REMOTE, constants.OSG_AUTH_REMOTE]:
-                raise Error("""\
-Error: You may not build into the OSG repo when building from
-a non-OSG target.  You must switch git repos or build targets.
-Try adding "--repo=hcc" to the command line.""")
-            if "upcoming" in branch:
-                raise Error("""\
-Error: Incorrect branch for koji build
-Only allowed to build packages from one of the upcoming branches
-into the upcoming targets.  Either switch the branch to master,
- or pass the appropriate --upcoming or --3.X-upcoming flag.""")
+
+
+def _do_target_remote_checks_osg(remote):
+    if remote not in [constants.OSG_REMOTE, constants.OSG_AUTH_REMOTE]:
+        raise Error("""\
+Error: You must build into the OSG repo from an OSG git checkout.
+You must switch git repos or build targets.""")
+
+
+def _do_target_remote_checks_chtc(remote):
+    if remote not in [constants.CHTC_REMOTE, constants.CHTC_AUTH_REMOTE]:
+        raise Error("""\
+Error: You must build into the CHTC repo from a CHTC git checkout.
+You must switch git repos or build targets.""")
+
+
+def _do_target_remote_checks(target, remote, branch):
+        if target.startswith("hcc-"):
+            _do_target_remote_checks_hcc(remote, branch)
+        elif target.startswith("osg-"):
+            _do_target_remote_checks_osg(remote)
+        elif target.startswith("chtc-"):
+            _do_target_remote_checks_chtc(remote)
 
 
 def koji(package_dir, koji_obj, buildopts):

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -430,11 +430,17 @@ Error: You must build into the OSG repo from an OSG git checkout.
 You must switch git repos or build targets.""")
 
 
-def _do_target_remote_checks_chtc(remote):
+def _do_target_remote_checks_chtc(remote, branch):
     if remote not in [constants.CHTC_REMOTE, constants.CHTC_AUTH_REMOTE]:
         raise Error("""\
 Error: You must build into the CHTC repo from a CHTC git checkout.
 You must switch git repos or build targets.""")
+
+    if "main" not in branch:
+        raise Error("""\
+Error: Incorrect branch for koji build
+Only allowed to build into the CHTC repo from the
+main branch!  You must switch branches.""")
 
 
 def _do_target_remote_checks(target, remote, branch):
@@ -443,7 +449,7 @@ def _do_target_remote_checks(target, remote, branch):
         elif target.startswith("osg-"):
             _do_target_remote_checks_osg(remote)
         elif target.startswith("chtc-"):
-            _do_target_remote_checks_chtc(remote)
+            _do_target_remote_checks_chtc(remote, branch)
 
 
 def koji(package_dir, koji_obj, buildopts):


### PR DESCRIPTION
INF-1662

These have the usual 3-part (development, testing, release) structure. There's no prerelease so the 'chtc-release' promotion route goes directly from testing to release.

The default is el9 only but el8 is also available (pass --el8 when building or promoting).

CHTC repos use the https://github.com/CHTC/packaging.git repo to build from.  Since the ".git" at the end is optional, I made some changes to "normalize" the remote URL for our various checks.