### PR TITLE
SOFTWARE-5702: OSG 23 empty/contrib build targets

### DIFF
--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -133,6 +133,7 @@ REPO_HINTS_STATIC = {
     'internal': {'target': 'osg-%(dver)s-internal', 'tag': 'osg-%(dver)s'},
     'devops': {'target': 'devops-%(dver)s', 'tag': 'osg-%(dver)s'},
     'hcc': {'target': 'hcc-%(dver)s', 'tag': 'hcc-%(dver)s'},
+    'empty': {'target': 'osg-%(dver)s-empty', 'tag': 'osg-%(dver)s'},
 }
 
 BUGREPORT_EMAIL = "help@osg-htc.org"

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -133,7 +133,6 @@ REPO_HINTS_STATIC = {
     'internal': {'target': 'osg-%(dver)s-internal', 'tag': 'osg-%(dver)s'},
     'devops': {'target': 'devops-%(dver)s', 'tag': 'osg-%(dver)s'},
     'hcc': {'target': 'hcc-%(dver)s', 'tag': 'hcc-%(dver)s'},
-    'empty': {'target': 'osg-%(dver)s-empty', 'tag': 'osg-%(dver)s'},
 }
 
 BUGREPORT_EMAIL = "help@osg-htc.org"

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -249,6 +249,7 @@ def repo_hints(targets):
                 osg_main_match = re.match(r'osg-(\d+)-main-el\d+', target)
                 osg_upcoming_match = re.match(r'osg-([0-9.]+)-upcoming-el\d+', target)
                 osg_internal_match = re.match(r'osg-(\d+)-internal-el\d+', target)
+                osg_empty_match = re.match(r'osg-([0-9.]+)-el\d+-empty', target)
                 if osg_match:
                     osgver = osg_match.group(1)
                     __repo_hints_cache[osgver] = __repo_hints_cache['osg-%s' % osgver] = {'target': 'osg-%s-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
@@ -261,6 +262,9 @@ def repo_hints(targets):
                 elif osg_internal_match:
                     osgver = osg_internal_match.group(1)
                     __repo_hints_cache["%s-internal" % osgver] = {'target': 'osg-%s-internal-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
+                elif osg_empty_match:
+                    osgver = osg_empty_match.group(1)
+                    __repo_hints_cache["%s-empty" % osgver] = {'target': 'osg-%s-%%(dver)s-empty' % osgver, 'tag': 'osg-%(dver)s'}
 
     return __repo_hints_cache
 

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -250,7 +250,14 @@ def repo_hints(targets):
                 osg_upcoming_match = re.match(r'osg-([0-9.]+)-upcoming-el\d+', target)
                 osg_internal_match = re.match(r'osg-(\d+)-internal-el\d+', target)
                 osg_empty_match = re.match(r'osg-([0-9.]+)-el\d+-empty', target)
-                if osg_match:
+                osg_contrib_match = re.match(r'osg-([0-9.]+)-el\d+-contrib', target)
+                if osg_empty_match:
+                    osgver = osg_empty_match.group(1)
+                    __repo_hints_cache["%s-empty" % osgver] = {'target': 'osg-%s-%%(dver)s-empty' % osgver, 'tag': 'osg-%(dver)s'}
+                elif osg_contrib_match:
+                    osgver = osg_contrib_match.group(1)
+                    __repo_hints_cache["%s-contrib" % osgver] = {'target': 'osg-%s-%%(dver)s-contrib' % osgver, 'tag': 'osg-%(dver)s'}
+                elif osg_match:
                     osgver = osg_match.group(1)
                     __repo_hints_cache[osgver] = __repo_hints_cache['osg-%s' % osgver] = {'target': 'osg-%s-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
                 elif osg_main_match:
@@ -262,9 +269,6 @@ def repo_hints(targets):
                 elif osg_internal_match:
                     osgver = osg_internal_match.group(1)
                     __repo_hints_cache["%s-internal" % osgver] = {'target': 'osg-%s-internal-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
-                elif osg_empty_match:
-                    osgver = osg_empty_match.group(1)
-                    __repo_hints_cache["%s-empty" % osgver] = {'target': 'osg-%s-%%(dver)s-empty' % osgver, 'tag': 'osg-%(dver)s'}
 
     return __repo_hints_cache
 


### PR DESCRIPTION
- Update `repo_hints()` in main.py to allow the new `osg-23-elX-{empty|contrib}` build targets as arguments to `osg-build`
Additional configuration steps required in koji are documented in JIRA: https://opensciencegrid.atlassian.net/browse/SOFTWARE-5702