### PR TITLE
Add support for submodules in .source files

### DIFF
--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -25,6 +25,7 @@ Possible fields names:
     uri:      uri for file to download (type=uri)
     filename: outfile if different than uri basename (type=uri, optional)
     sha1sum:  chksum of downloaded file (type=uri/cached, optional)
+    submodules: true/false if we should include submodules in the archive (type=git/github, optional)
 
 
 Each line is associated with a source 'type':
@@ -67,6 +68,8 @@ import sys
 import urllib
 import urllib.error
 import urllib.request
+
+from typing import Optional
 
 from . import constants as C
 from .error import Error, GlobNotFoundError
@@ -222,7 +225,26 @@ def unchecked_call2(*args, **kw):
     return utils.sbacktick(*args, err2out=True, **kw)[1] == 0
 
 
-def git_archive_remote_ref(url, tag, hash, prefix, tarball, spec, submodules, ops):
+def git_archive_remote_ref(
+        url: str, tag: str, hash: Optional[str], prefix: str, tarball: str,
+        spec: Optional[str], submodules: bool, ops: FetchOptions
+):
+    """
+    Create a tarball from a git tag (or branch) using git archive, optionally with submodules.
+
+    Args:
+        url: the upstream URL of the git repo
+        tag: the tag (or branch) to create the archive from
+        hash: optional, the sha1 hash of the tag/branch, used for verification
+        prefix: the directory prefix of the files in the created tarball
+        tarball: the name of the created tarball
+        spec: optional, the path to the spec file within the git repo
+        submodules: boolean, set to true if we should fetch submodules after checking out the main repo
+        ops: other options
+
+    Returns:
+        The path to the created tarball.
+    """
     log.info('Retrieving %s %s' % (url, tag))
     try:
         checked_call2(['git', 'clone', '--branch', tag, url, '.'])
@@ -236,20 +258,28 @@ def git_archive_remote_ref(url, tag, hash, prefix, tarball, spec, submodules, op
 
     dest_tar_gz = os.path.join(ops.destdir, tarball)
     dest_tar = dest_tar_gz[:-len('.gz')]
-    git_archive_cmd = ['git', 'archive', '--format=tar',
-                                         '--prefix=%s/' % prefix,
-                                         '--output=%s' % dest_tar, got_sha]
-    utils.checked_call(git_archive_cmd)
+    # Create the initial tarball with the contents of the repo
+    utils.checked_call([
+        'git', 'archive', f'--prefix={prefix}/', f'--output={dest_tar}', got_sha
+    ])
 
     if submodules and str(submodules).lower() not in {"none", "false", "0"}:
+        # We are asked for submodules. Pull all the submodules:
         utils.checked_call(['git', 'submodule', 'update', '--init', '--recursive'])
-        utils.checked_call(['git', 'submodule', 'foreach', '--recursive',
-                            'git archive --prefix=%s/$path/ --output=$sha1.tar HEAD && '
-                            'tar --concatenate --file=%s $sha1.tar && '
-                            'rm $sha1.tar' % (prefix, dest_tar)])
+        # Create a tarball for each submodule, then append that tarball to the main tarball.
+        # The following command will be run by git for each submodule --
+        # $path and $sha1 will be substituted in by 'git submodule foreach'
+        submodule_archive_command = (
+            f'git archive --prefix={prefix}/$path/ --output=$sha1.tar HEAD && '
+            f'tar --concatenate --file={dest_tar} $sha1.tar && '
+            f'rm $sha1.tar'
+        )
+        utils.checked_call(['git', 'submodule', 'foreach', '--recursive', submodule_archive_command])
 
+    # compress the result
     utils.checked_call(['gzip', '-fn', dest_tar])
 
+    # if we were told there is a spec file, copy it out of the repo
     if spec:
         spec = try_get_spec(ops.destdir, got_sha, spec)
 


### PR DESCRIPTION
This adds the optional `submodules` flag to sources in .source files of `type=git` or `type=github`.  If `submodules=true` then submodules will be checked out and included in the generated tarball as well.