### PR TITLE
V2 cleanup

### DIFF
--- a/.git-blame-ignore-list
+++ b/.git-blame-ignore-list
@@ -1,1 +1,2 @@
 # add commit hashes here, one per line, that should be ignored in `git blame`
+da595f4bfd1783e38093fffa90d1b6893d50407e

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -98,7 +98,6 @@ DEFAULT_BUILDOPTS_COMMON = {
     'regen_repos': False,
     'repo': 'osg',
     'scratch': False,
-    'vcs': None,
     'target_arch': None,
     'working_directory': '.',
 }

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -39,30 +39,30 @@ SVN_REDHAT_PATH = "/native/redhat"
 
 # fmt: off
 SVN_RESTRICTED_BRANCHES = {
-    r'^branches/(?P<osgver>[0-9.]+)-upcoming$': 'upcoming',
-    r'^branches/osg-internal$'             : 'oldinternal',
-    r'^branches/devops$'                   : 'devops',
-    r'^branches/osg-(?P<osgver>\d+\.\d+)$' : 'versioned',
-    r'^branches/(?P<osgver>[0-9.]+)-main$' : 'versioned',
-    r'^branches/(?P<osgver>[0-9.]+)-internal$' : 'internal',
+    r'^branches/(?P<osgver>[0-9.]+)-upcoming$'  : 'upcoming',
+    r'^branches/osg-internal$'                  : 'oldinternal',
+    r'^branches/devops$'                        : 'devops',
+    r'^branches/osg-(?P<osgver>\d+\.\d+)$'      : 'versioned',
+    r'^branches/(?P<osgver>[0-9.]+)-main$'      : 'versioned',
+    r'^branches/(?P<osgver>[0-9.]+)-internal$'  : 'internal',
 }
 KOJI_RESTRICTED_TARGETS = {
-    r'^osg-(el\d+)$'                       : 'main',
-    r'^osg-(?P<osgver>[0-9.]+)-upcoming-(el\d+)$': 'upcoming',
-    r'^devops-(el\d+)$'                    : 'devops',
-    r'^osg-(el\d+)-internal$'              : 'oldinternal',
-    r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'  : 'versioned',
-    r'^osg-(?P<osgver>[0-9.]+)-main-(el\d+)$'     : 'versioned',
-    r'^osg-(?P<osgver>[0-9.]+)-internal-(el\d+)$' : 'internal',
-    r'^chtc-(el\d+)$'                      : 'chtc',
+    r'^osg-(el\d+)$'                                : 'main',
+    r'^osg-(?P<osgver>[0-9.]+)-upcoming-(el\d+)$'   : 'upcoming',
+    r'^devops-(el\d+)$'                             : 'devops',
+    r'^osg-(el\d+)-internal$'                       : 'oldinternal',
+    r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'           : 'versioned',
+    r'^osg-(?P<osgver>[0-9.]+)-main-(el\d+)$'       : 'versioned',
+    r'^osg-(?P<osgver>[0-9.]+)-internal-(el\d+)$'   : 'internal',
+    r'^chtc-(el\d+)$'                               : 'chtc',
 }
 GIT_RESTRICTED_BRANCHES = {
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-upcoming$': 'upcoming',
-    r'^(\w*/)?internal$'                   : 'oldinternal',
-    r'^(\w*/)?devops$'                     : 'devops',
-    r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'   : 'versioned',
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-main$'   : 'versioned',
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-internal$' : 'internal',
+    r'^(\w*/)?(?P<osgver>[0-9.]+)-upcoming$'    : 'upcoming',
+    r'^(\w*/)?internal$'                        : 'oldinternal',
+    r'^(\w*/)?devops$'                          : 'devops',
+    r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'        : 'versioned',
+    r'^(\w*/)?(?P<osgver>[0-9.]+)-main$'        : 'versioned',
+    r'^(\w*/)?(?P<osgver>[0-9.]+)-internal$'    : 'internal',
 }
 # fmt: on
 

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -52,8 +52,8 @@ KOJI_RESTRICTED_TARGETS = {
     r'^devops-(el\d+)$'                    : 'devops',
     r'^osg-(el\d+)-internal$'              : 'oldinternal',
     r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'  : 'versioned',
-    r'^(?P<osgver>[0-9.]+)-main-(el\d+)$'  : 'versioned',
-    r'^(?P<osgver>[0-9.]+)-internal-(el\d+)$' : 'internal',
+    r'^osg-(?P<osgver>[0-9.]+)-main-(el\d+)$'     : 'versioned',
+    r'^osg-(?P<osgver>[0-9.]+)-internal-(el\d+)$' : 'internal',
     r'^chtc-(el\d+)$'                      : 'chtc',
 }
 GIT_RESTRICTED_BRANCHES = {

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -85,7 +85,6 @@ GIT_REMOTE_MAPS = {HCC_AUTH_REMOTE: HCC_REMOTE,
                    CHTC_AUTH_REMOTE: CHTC_REMOTE}
 
 DEFAULT_BUILDOPTS_COMMON = {
-    'autoclean': True,
     'background': False,
     'cache_prefix': 'AUTO',
     'dry_run': False,

--- a/osgbuild/error.py
+++ b/osgbuild/error.py
@@ -35,16 +35,10 @@ class ConfigErrors(Error):
         return repr((self.msg, self.errors))
 
 
-class SVNError(Error):
-    """Error doing SVN actions"""
+class VCSError(Error):
+    """Errors related to version control systems"""
     def __init__(self, msg):
-        Error.__init__(self, "SVN error: %s" % msg)
-
-
-class GitError(Error):
-    """Error doing Git actions"""
-    def __init__(self, msg):
-        Error.__init__(self, "Git error: %s" % msg)
+        Error.__init__(self, "Version Control System error: %s" % msg)
 
 
 class GlobNotFoundError(Error):

--- a/osgbuild/error.py
+++ b/osgbuild/error.py
@@ -38,7 +38,7 @@ class ConfigErrors(Error):
 class VCSError(Error):
     """Errors related to version control systems"""
     def __init__(self, msg):
-        Error.__init__(self, "Version Control System error: %s" % msg)
+        Error.__init__(self, "Version Control System error:\n%s" % msg)
 
 
 class GlobNotFoundError(Error):

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -6,7 +6,7 @@ from urllib.parse import urlsplit  # Python 3
 
 
 from .constants import GIT_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
-from .error import Error, GitError
+from .error import Error, VCSError
 from . import utils
 from . import constants
 
@@ -163,14 +163,14 @@ def get_branch(package_dir):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "branch"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git branch for directory %s.  Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git branch for directory %s.  Output:\n%s" % (err, package_dir, out))
     out = out.strip()
     if not out:
-        raise GitError("'git branch' returned no output.")
+        raise VCSError("'git branch' returned no output.")
 
     branch = [ line[2:] for line in out.splitlines() if line.startswith('* ') ]
     if len(branch) != 1 or not branch[0] or ' ' in branch[0]:
-        raise GitError("'git branch' indicates no branch is checked out")
+        raise VCSError("'git branch' indicates no branch is checked out")
     return branch[0]
 
 
@@ -183,7 +183,7 @@ def get_known_remote(package_dir):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "remote", "-v"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     for line in out.splitlines():
         info = line.strip().split()
         if len(info) != 3:
@@ -194,7 +194,7 @@ def get_known_remote(package_dir):
         remote_url = _normalize_remote(info[1])
         if remote_url in constants.KNOWN_GIT_REMOTES:
             return remote_name, remote_url
-    raise GitError("Known remote not found for directory %s; are remotes configurated correctly?" % package_dir)
+    raise VCSError("Known remote not found for directory %s; are remotes configurated correctly?" % package_dir)
 
 
 def get_fetch_url(package_dir, remote):
@@ -204,7 +204,7 @@ def get_fetch_url(package_dir, remote):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "remote", "-v"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     for line in out.splitlines():
         info = line.strip().split()
         if len(info) != 3:
@@ -216,7 +216,7 @@ def get_fetch_url(package_dir, remote):
         if dir_remote_name == remote:
             return constants.GIT_REMOTE_MAPS.setdefault(dir_remote_url, dir_remote_url)
 
-    raise GitError("Remote URL not found for remote %s in directory %s; are remotes " \
+    raise VCSError("Remote URL not found for remote %s in directory %s; are remotes " \
         "configured correctly?" % (remote, package_dir))
 
 def get_current_branch_remote(package_dir):
@@ -228,7 +228,7 @@ def get_current_branch_remote(package_dir):
                "config", "branch.%s.remote" % branch]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git branch %s remote for directory '%s'. Output:\n%s" % \
+        raise VCSError("Exit code %d getting git branch %s remote for directory '%s'. Output:\n%s" % \
                        (err, branch, package_dir, out))
 
     return out.strip()
@@ -240,7 +240,7 @@ def is_uncommitted(package_dir):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "status", "--porcelain"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     if out:
         print("The following uncommitted changes exist:")
         print(out)
@@ -256,7 +256,7 @@ def is_uncommitted(package_dir):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "show-ref"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git references for directory %s.  Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git references for directory %s.  Output:\n%s" % (err, package_dir, out))
     branch_hash = ''
     origin_hash = ''
     for line in out.splitlines():
@@ -269,11 +269,11 @@ def is_uncommitted(package_dir):
             origin_hash = info[0]
 
     if not branch_hash and not origin_hash:
-        raise GitError("Could not find either local or remote hash for directory %s." % package_dir)
+        raise VCSError("Could not find either local or remote hash for directory %s." % package_dir)
     if branch_hash != origin_hash:
-        raise GitError("Local hash (%s) does not match remote hash "
+        raise VCSError("Local hash (%s) does not match remote hash "
             "(%s) for directory %s.  Perhaps you need to perform 'git push'?" % \
-            (branch_hash, origin_hash, package_dir))
+                       (branch_hash, origin_hash, package_dir))
 
     return False
 
@@ -292,7 +292,7 @@ def is_outdated(package_dir):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "show-ref"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git references for directory %s.  Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git references for directory %s.  Output:\n%s" % (err, package_dir, out))
     for line in out.splitlines():
         info = line.strip().split()
         if len(info) != 2:
@@ -301,12 +301,12 @@ def is_outdated(package_dir):
             branch_hash = info[0]
             break
     if not branch_hash:
-        raise GitError("Unable to determine local branch's hash.")
+        raise VCSError("Unable to determine local branch's hash.")
 
     out, err = utils.sbacktick(["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"),
                                 "ls-remote", "--heads", remote])
     if err:
-        raise GitError("Exit code %d getting remote git status for directory %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting remote git status for directory %s. Output:\n%s" % (err, package_dir, out))
 
     remote_hash = ''
     for line in out.splitlines():
@@ -317,7 +317,7 @@ def is_outdated(package_dir):
             remote_hash = info[0]
             break
     if not remote_hash:
-        raise GitError("Unable to determine remote branch's hash.")
+        raise VCSError("Unable to determine remote branch's hash.")
 
     if remote_hash == branch_hash:
         return False
@@ -355,14 +355,14 @@ def verify_package_dir(package_dir):
                "rev-parse", "--show-toplevel"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git top-level directory of %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git top-level directory of %s. Output:\n%s" % (err, package_dir, out))
     if top_dir != out.strip():
-        raise GitError("Specified package directory (%s) is not a top-level directory in the git repo (%s)." % \
+        raise VCSError("Specified package directory (%s) is not a top-level directory in the git repo (%s)." % \
                        (package_dir, top_dir))
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "ls-files", "osg", "upstream"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git subdirectories of %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git subdirectories of %s. Output:\n%s" % (err, package_dir, out))
     for line in out.split("\n"):
         if line.startswith('osg/') or line.startswith('upstream/'):
             return True
@@ -375,13 +375,13 @@ def verify_git_svn_commit(package_dir):
     command = ["git", "--work-tree", top_dir, "--git-dir", os.path.join(top_dir, ".git"), "log", "-n", "1"]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise GitError("Exit code %d getting git log for directory %s. Output:\n%s" % (err, package_dir, out))
+        raise VCSError("Exit code %d getting git log for directory %s. Output:\n%s" % (err, package_dir, out))
 
     for line in out.splitlines():
         if line.find("git-svn-id:") >= 0:
             return
 
-    raise GitError("Last git commit not from SVN - possible inconsistency between git and SVN!")
+    raise VCSError("Last git commit not from SVN - possible inconsistency between git and SVN!")
 
 
 def verify_correct_remote(package_dir):
@@ -389,7 +389,7 @@ def verify_correct_remote(package_dir):
     remote = get_current_branch_remote(package_dir)
     known_remote = get_known_remote(package_dir)[0]
     if remote != known_remote:
-        raise GitError("Remote %s for directory %s is not an officially known remote." % (remote, package_dir))
+        raise VCSError("Remote %s for directory %s is not an officially known remote." % (remote, package_dir))
 
 
 def verify_correct_branch(package_dir, buildopts):
@@ -400,7 +400,7 @@ def verify_correct_branch(package_dir, buildopts):
         # a git url -- we can only do some of our checks
         remote, _, branch = parse_git_url(package_dir)
         if not remote:
-            raise GitError("URL %s failed to parse as a git URL" % package_dir)
+            raise VCSError("URL %s failed to parse as a git URL" % package_dir)
     else:
         branch = get_branch(package_dir)
         remote = get_known_remote(package_dir)[1]
@@ -424,7 +424,7 @@ def verify_correct_branch(package_dir, buildopts):
             # Some custom target -- any branch ok
             continue
         if not restricted_branch_matches_target(branch, target):
-            raise GitError("Forbidden to build from %s branch into %s target" % (branch, target))
+            raise VCSError("Forbidden to build from %s branch into %s target" % (branch, target))
 
 
 def _do_target_remote_checks_hcc(remote, branch):
@@ -487,7 +487,7 @@ def koji(package_dir, koji_obj, buildopts):
                    "log", "-1", "--pretty=format:%H"]
         out, err = utils.sbacktick(command, err2out=True)
         if err:
-            raise GitError("Exit code %d getting git hash for directory %s. Output:\n%s" % (err, package_dir, out))
+            raise VCSError("Exit code %d getting git hash for directory %s. Output:\n%s" % (err, package_dir, out))
         rev = out.strip()
 
     if not re.match(r"\w+", package_name): # sanity check

--- a/osgbuild/kojiinter.py
+++ b/osgbuild/kojiinter.py
@@ -6,16 +6,13 @@ import json
 import logging
 import random
 import re
-import os
 import string
-import sys
 import time
 import urllib
 import urllib.request, urllib.error
 from typing import Optional, List, NamedTuple, Set, Dict
 
 from .constants import *
-from . import clientcert, constants
 from . import utils
 from .error import KojiError, type_of_error
 from .utils import split_nvr
@@ -125,7 +122,7 @@ class KojiInter(object):
     """An interface around the koji cli"""
     backend = None
 
-    def __init__(self, opts):
+    def __init__(self, opts, dry_run=None):
         self.no_wait = opts['no_wait']
         self.regen_repos = opts['regen_repos']
         self.scratch = opts['scratch']
@@ -133,16 +130,18 @@ class KojiInter(object):
         if self.arch_override and not self.scratch:
             log.warning("target-arch ignored on non-scratch builds")
             self.arch_override = None
+        if dry_run is None:
+            dry_run = opts['dry_run']
 
         if KojiInter.backend is None:
             if not HAVE_KOJILIB and opts['koji_backend'] == 'kojilib':
                 raise KojiError("KojiLib backend requested, but can't import it!")
             elif HAVE_KOJILIB and opts.get('koji_backend') != 'shell':
                 log.debug("KojiInter Using KojiLib backend")
-                KojiInter.backend = KojiLibInter(opts['dry_run'])
+                KojiInter.backend = KojiLibInter(dry_run)
             else:
                 log.debug("KojiInter Using shell backend")
-                KojiInter.backend = KojiShellInter(opts['dry_run'])
+                KojiInter.backend = KojiShellInter(dry_run)
             KojiInter.backend.read_config_file()
             KojiInter.backend.init_koji_session()
 

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -12,6 +12,7 @@ import sys
 import tempfile
 import configparser
 
+from utils import get_dver_from_string
 from .constants import *
 from .error import UsageError, KojiError, SVNError, GitError, Error, type_of_error
 from . import srpm
@@ -47,7 +48,7 @@ def main(argv=None):
         argv = sys.argv
 
     buildopts, package_dirs, task = init(argv)
-    vcs = None
+    vcs_module = None
 
     if task in ['koji', 'mock']:
         for build_dver in buildopts['enabled_dvers']:
@@ -56,27 +57,25 @@ def main(argv=None):
                 targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
                 targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
     # checks
-    if task == 'koji' and buildopts['vcs']:
+    if task == 'koji' and buildopts['want_vcs']:
         # verify working dirs
         for pkg in package_dirs:
-            # vcs is the module for accessing the repo
-            vcs = svn if svn.is_svn(pkg) else git if git.is_git(pkg) else None
-            if vcs and not utils.is_url(pkg):
+            # vcs_module is the module for accessing the repo
+            vcs_module = svn if svn.is_svn(pkg) else git if git.is_git(pkg) else None
+            if not vcs_module:
+                log.error("VCS build requested but could not determine VCS (SVN or Git) for %s", pkg)
+                return 1
+
+            if not utils.is_url(pkg):
                 try:
-                    vcs.verify_working_dir(pkg)
+                    vcs_module.verify_working_dir(pkg)
                 except (SVNError, GitError) as err:
                     log.error(str(err))
                     log.error("VCS build requested but no usable VCS (SVN or Git) found for %s", pkg)
                     return 1
 
             if not buildopts['scratch']:
-                if not vcs:
-                    log.error(
-                        "Non-scratch builds must be built from a VCS and no usable VCS (SVN or Git) was found for %s",
-                        pkg
-                    )
-                    return 1
-                vcs.verify_correct_branch(pkg, buildopts)
+                vcs_module.verify_correct_branch(pkg, buildopts)
     else:
         # verify package dirs
         for pkg in package_dirs:
@@ -87,9 +86,6 @@ def main(argv=None):
                 raise UsageError(pkg +
                     " isn't a package directory "
                     "(must have either osg/ or upstream/ dirs or both)")
-
-    if (task == 'koji' and not buildopts['scratch'] and not buildopts['vcs']):
-        raise UsageError("Non-scratch Koji builds must be from SVN!")
 
     if task == 'koji' and len(package_dirs) >= BACKGROUND_THRESHOLD:
         buildopts['background'] = True
@@ -119,8 +115,8 @@ def main(argv=None):
                     koji_obj = kojiinter.KojiInter(dver_buildopts_)
                 mock_obj = mock.Mock(dver_buildopts, koji_obj)
 
-            if buildopts['vcs'] and task == 'koji':
-                task_ids.append(vcs.koji(pkg, koji_obj, dver_buildopts))
+            if buildopts['want_vcs'] and task == 'koji':
+                task_ids.append(vcs_module.koji(pkg, koji_obj, dver_buildopts))
             else:
                 builder = srpm.SRPMBuild(pkg,
                                          dver_buildopts,
@@ -151,7 +147,7 @@ def main(argv=None):
             # TODO This is not implemented for the KojiShellInter backend
             # Not implemented for SVN builds since results_dir is undefined for those
             if buildopts['getfiles']:
-                if buildopts['vcs']:
+                if buildopts['want_vcs']:
                     log.warning("--getfiles is only for SRPM builds")
                 elif not isinstance(kojiinter.KojiInter.backend, kojiinter.KojiLibInter):
                     log.warning("--getfiles is only implemented on the KojiLib backend")
@@ -364,11 +360,6 @@ rpmbuild     Build using rpmbuild(8) on the local machine
     parser.add_option(
         "--version", action="store_true",
         help="Show version and exit.")
-    parser.add_option(
-        "-w", "--working-directory",
-        help="The base directory to use for temporary files made by the "
-        "script. If it is 'TEMP', a randomly-named directory under /tmp "
-        "is used. Default: package directory")
 
     prebuild_group = OptionGroup(parser,
                                  "prebuild task options")
@@ -471,13 +462,9 @@ rpmbuild     Build using rpmbuild(8) on the local machine
             "--no-scratch", "--noscratch", action="store_false", dest="scratch",
             help="Do not perform a scratch build (default)")
         koji_group.add_option(
-            "--vcs", "--svn", action="store_true", dest="vcs",
-            help="Build package directly from SVN/Git "
-            "(default for non-scratch builds)")
-        koji_group.add_option(
-            "--no-vcs", "--novcs", "--no-svn", "--nosvn", action="store_false", dest="vcs",
-            help="Do not build package directly from SVN/Git "
-            "(default for scratch builds)")
+            "--vcs", "--svn", action="store_true", dest="want_vcs",
+            help="Build package directly from SVN/Git (always true for non-scratch builds)"
+        )
         koji_group.add_option(
             "--repo", action="callback",
             callback=parser_targetopts_callback,
@@ -490,22 +477,13 @@ rpmbuild     Build using rpmbuild(8) on the local machine
         )
         parser.add_option_group(koji_group)
 
+    parser.set_defaults(want_vcs=False)
+
     options, args = parser.parse_args(argv[1:])
 
     return (options, args)
 # end of parse_cmdline_args()
 
-
-def get_dver_from_string(s):
-    """Get the EL major version from a string containing it.
-    Return None if not found."""
-    if not s:
-        return None
-    match = re.search(r'\b(el\d+)\b', s)
-    if match is not None:
-        return match.group(1)
-    else:
-        return None
 
 def target_for_repo_hint(repo_hint, dver):
     hints = repo_hints(valid_koji_targets())
@@ -640,9 +618,6 @@ def get_buildopts(options, task):
 
     buildopts = DEFAULT_BUILDOPTS_COMMON.copy()
 
-    # Backward compatibility for 'svn' option:
-    buildopts['vcs'] = buildopts.get('vcs') or buildopts.get('svn')
-
     # Overrides from command line
     for optname in options.__dict__.keys():
         optval = getattr(options, optname, None)
@@ -685,11 +660,9 @@ def get_buildopts(options, task):
             machine_dver = utils.get_local_machine_dver() or FALLBACK_DVER
             buildopts['enabled_dvers'] = {machine_dver}
 
-    if kojiinter and buildopts['vcs'] is None and task == 'koji':
-        if buildopts['scratch']:
-            buildopts['vcs'] = False
-        else:
-            buildopts['vcs'] = True
+    if kojiinter and task == "koji":
+        if not buildopts["scratch"]:
+            buildopts['want_vcs'] = True
 
     return buildopts
 # end of get_buildopts()

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -11,7 +11,7 @@ import configparser
 
 from utils import get_dver_from_string
 from .constants import *
-from .error import UsageError, KojiError, SVNError, GitError, Error, type_of_error
+from .error import UsageError, KojiError, VCSError, Error, type_of_error
 from . import srpm
 from . import svn
 from . import git
@@ -42,7 +42,14 @@ log.addHandler(log_consolehandler)
 
 
 def koji_main(buildopts, package_dirs):
-    # TODO Document
+    """
+    Main function for the "koji" task.  Verify package directories (or URLs)
+    and run a Koji build for each of them, downloading the results if in
+    'getfiles' mode.
+    Args:
+        buildopts: build options
+        package_dirs: a list of package directories or URLs
+    """
     if not kojiinter:
         raise KojiError("Koji module is not available")
 
@@ -58,16 +65,14 @@ def koji_main(buildopts, package_dirs):
             # vcs_module is the module for accessing the repo
             vcs_module = svn if svn.is_svn(pkg) else git if git.is_git(pkg) else None
             if not vcs_module:
-                log.error("VCS build requested but could not determine VCS (SVN or Git) for %s", pkg)
-                return 1
+                raise VCSError("VCS build requested but could not determine VCS (SVN or Git) for %s", pkg)
 
             if not utils.is_url(pkg):
                 try:
                     vcs_module.verify_working_dir(pkg)
-                except (SVNError, GitError) as err:
-                    log.error(str(err))
+                except VCSError as err:
                     log.error("VCS build requested but no usable VCS (SVN or Git) found for %s", pkg)
-                    return 1
+                    raise
 
             if not buildopts['scratch']:
                 vcs_module.verify_correct_branch(pkg, buildopts)
@@ -111,7 +116,7 @@ def koji_main(buildopts, package_dirs):
     # End of main loop
     #
 
-    return watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir)
+    watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir)
 
 
 def main(argv=None):
@@ -161,8 +166,19 @@ def main(argv=None):
 
 
 def watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir):
-    # TODO Document
-    # HACK
+    """
+    Print the task IDs and the Koji URLs where they can be watched.
+    If we're in no_wait mode, print out the osg-koji command to watch
+    the tasks; otherwise,  have Koji watch the tasks and print
+    out their progress.  If we know the results dirs and getfiles is on,
+    also get the logs and the files at the end.
+
+    Args:
+        buildopts: The build options dict
+        task_ids: A list of Koji task IDs
+        task_ids_by_results_dir: A dict, keyed by results_dir, of the lists
+            of the associated tasks; only used if getfiles is on.
+    """
     task_ids = sorted(filter(None, task_ids))
     if kojiinter and kojiinter.KojiInter.backend and task_ids:
         try:
@@ -177,16 +193,11 @@ def watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir):
             print("To watch tasks, run:")
             print("osg-koji watch-tasks %s" % " ".join(task_ids))
             print()
-            return 0
-    ret = kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
+    kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
     if buildopts['getfiles']:
         for destdir, tids in task_ids_by_results_dir.items():
             if kojiinter.KojiInter.backend.download_results(tids, destdir):
                 log.info("Results and logs downloaded to %s", destdir)
-    try:
-        return int(ret)
-    except (TypeError, ValueError):
-        pass
 
 
 def is_pkg_dir(pkg):

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -126,7 +126,7 @@ def main(argv=None):
                                          dver_buildopts,
                                          mock_obj=mock_obj,
                                          koji_obj=koji_obj)
-                builder.maybe_autoclean()
+                builder.clean_previous()
                 method = getattr(builder, task)
                 if task == 'koji':
                     task_ids_by_results_dir.setdefault(builder.results_dir, [])
@@ -324,14 +324,6 @@ rpmbuild     Build using rpmbuild(8) on the local machine
         header += "\n" + header_post
 
     parser = OptionParser(header)
-    parser.add_option(
-        "-a", "--autoclean", action="store_true",
-        help="Clean out the following directories before each build: "
-        "'%s', '%s', '%s', '%s' (default)" % (
-            WD_RESULTS, WD_PREBUILD, WD_UNPACKED, WD_UNPACKED_TARBALL))
-    parser.add_option(
-        "--no-autoclean", action="store_false", dest="autoclean",
-        help="Disable autoclean")
     parser.add_option(
         "-c", "--cache-prefix",
         help="The prefix for the software cache to take source files from. "

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -1,9 +1,6 @@
 """osg build script"""
 
 
-# TODO Shouldn't need koji access for 'rpmbuild', but currently does since it
-# gets the values for the --repo arg -- which is only used for koji builds.
-# Make it so.
 import logging
 import traceback
 from optparse import OptionGroup, OptionParser, OptionValueError
@@ -49,11 +46,6 @@ def koji_main(buildopts, package_dirs):
     if not kojiinter:
         raise KojiError("Koji module is not available")
 
-    for build_dver in buildopts['enabled_dvers']:
-        targetopts = buildopts['targetopts_by_dver'][build_dver]  # modified in-place!
-        targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
-        targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
-
     vcs_module = None
 
     #
@@ -92,8 +84,10 @@ def koji_main(buildopts, package_dirs):
     for pkg in package_dirs:
         log.info("Performing task koji on package %s", pkg if utils.is_url(pkg) else os.path.basename(pkg))
         for build_dver in buildopts['enabled_dvers']:
-            dver_buildopts = buildopts.copy()
+            dver_buildopts = buildopts.copy()  # type: dict
             dver_buildopts.update(buildopts['targetopts_by_dver'][build_dver])
+            dver_buildopts.setdefault('koji_target', target_for_repo_hint(buildopts['repo'], build_dver))
+            dver_buildopts.setdefault('koji_tag', target_for_repo_hint(buildopts['repo'], build_dver))
 
             koji_obj = kojiinter.KojiInter(dver_buildopts)
 
@@ -130,23 +124,19 @@ def main(argv=None):
     if task == "koji":
         return koji_main(buildopts, package_dirs)
 
-    if task == "mock":
-        for build_dver in buildopts['enabled_dvers']:
-            if kojiinter:
-                targetopts = buildopts['targetopts_by_dver'][build_dver]  # modified in-place!
-                targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
-                targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
-
     # verify package dirs
     for pkg in package_dirs:
         is_pkg_dir(pkg)
 
     # main loop
     for pkg in package_dirs:
-        log.info("Performing task %s on package %s", task, pkg if utils.is_url(pkg) else os.path.basename(pkg))
+        log.info("Performing task %s on package %s", task, os.path.basename(pkg))
         for build_dver in buildopts['enabled_dvers']:
             dver_buildopts = buildopts.copy()
             dver_buildopts.update(buildopts['targetopts_by_dver'][build_dver])
+            if task == "mock" and kojiinter:
+                dver_buildopts.setdefault('koji_target', target_for_repo_hint(buildopts['repo'], build_dver))
+                dver_buildopts.setdefault('koji_tag', target_for_repo_hint(buildopts['repo'], build_dver))
 
             mock_obj = None
             koji_obj = None
@@ -154,10 +144,8 @@ def main(argv=None):
                 assert mock  # shouldn't get here without osg-build-mock
                 if dver_buildopts['mock_config_from_koji']:
                     assert kojiinter  # shouldn't get here without osg-build-koji
-                    # HACK: We don't want to log in to koji just to get a mock config
-                    dver_buildopts_ = dver_buildopts.copy()
-                    dver_buildopts_['dry_run'] = True
-                    koji_obj = kojiinter.KojiInter(dver_buildopts_)
+                    # We don't want to log in to koji just to get a mock config
+                    koji_obj = kojiinter.KojiInter(dver_buildopts, dry_run=True)
                 mock_obj = mock.Mock(dver_buildopts, koji_obj)
 
             builder = srpm.SRPMBuild(pkg,
@@ -185,6 +173,10 @@ def watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir):
         for tid in task_ids:
             print(koji_weburl + "/taskinfo?taskID=" + str(tid))
         if buildopts["no_wait"]:
+            print()
+            print("To watch tasks, run:")
+            print("osg-koji watch-tasks %s" % " ".join(task_ids))
+            print()
             return 0
     ret = kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
     if buildopts['getfiles']:
@@ -207,7 +199,6 @@ def is_pkg_dir(pkg):
                          "(must have either osg/ or upstream/ dirs or both)")
 
 
-# end of main()
 
 
 def init(argv):

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -144,24 +144,14 @@ def main(argv=None):
             print(koji_weburl + "/taskinfo?taskID=" + str(tid))
         if not buildopts['no_wait']:
             ret = kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
-            # TODO This is not implemented for the KojiShellInter backend
-            # Not implemented for SVN builds since results_dir is undefined for those
             if buildopts['getfiles']:
-                if buildopts['want_vcs']:
-                    log.warning("--getfiles is only for SRPM builds")
-                elif not isinstance(kojiinter.KojiInter.backend, kojiinter.KojiLibInter):
-                    log.warning("--getfiles is only implemented on the KojiLib backend")
-                else:
-                    for destdir, tids in task_ids_by_results_dir.items():
-                        if kojiinter.KojiInter.backend.download_results(tids, destdir):
-                            log.info("Results and logs downloaded to %s", destdir)
+                for destdir, tids in task_ids_by_results_dir.items():
+                    if kojiinter.KojiInter.backend.download_results(tids, destdir):
+                        log.info("Results and logs downloaded to %s", destdir)
             try:
                 return int(ret)
             except (TypeError, ValueError):
                 pass
-        else:
-            if buildopts['getfiles']:
-                log.warning("Cannot use both --getfiles and --nowait")
 
     return 0
 # end of main()
@@ -663,6 +653,14 @@ def get_buildopts(options, task):
     if kojiinter and task == "koji":
         if not buildopts["scratch"]:
             buildopts['want_vcs'] = True
+        if buildopts["getfiles"]:
+            if buildopts["want_vcs"]:
+                # results_dir is undefined for VCS builds
+                raise UsageError("--getfiles is only for SRPM builds")
+            elif buildopts["no_wait"]:
+                raise UsageError("Cannot use both --getfiles and --nowait")
+            elif buildopts.get("koji_backend") == "shell" or not kojiinter.HAVE_KOJILIB:
+                raise UsageError("--getfiles is only implemented on the KojiLib backend")
 
     return buildopts
 # end of get_buildopts()

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -9,7 +9,6 @@ import sys
 import tempfile
 import configparser
 
-from utils import get_dver_from_string
 from .constants import *
 from .error import UsageError, KojiError, VCSError, Error, type_of_error
 from . import srpm
@@ -70,7 +69,7 @@ def koji_main(buildopts, package_dirs):
             if not utils.is_url(pkg):
                 try:
                     vcs_module.verify_working_dir(pkg)
-                except VCSError as err:
+                except VCSError:
                     log.error("VCS build requested but no usable VCS (SVN or Git) found for %s", pkg)
                     raise
 
@@ -543,7 +542,7 @@ def target_for_repo_hint(repo_hint, dver):
 def tag_for_repo_hint(repo_hint, dver):
     return repo_hints(valid_koji_targets())[repo_hint]['tag'] % {'dver': dver}
 
-def parser_targetopts_callback(option, opt_str, value, parser, *args, **kwargs): # unused-args: pylint:disable=W0613
+def parser_targetopts_callback(option, opt_str, value, parser, *_, **__):
     """Handle options in the 'targetopts_by_dver' set, such as --koji-tag,
     --redhat-release, etc.
 

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -42,24 +42,27 @@ log.addHandler(log_consolehandler)
 #-------------------------------------------------------------------------------
 # Main function
 #-------------------------------------------------------------------------------
-def main(argv=None):
-    """Main function."""
-    if argv is None:
-        argv = sys.argv
 
-    buildopts, package_dirs, task = init(argv)
+
+def koji_main(buildopts, package_dirs):
+    # TODO Document
+    if not kojiinter:
+        raise KojiError("Koji module is not available")
+
+    for build_dver in buildopts['enabled_dvers']:
+        targetopts = buildopts['targetopts_by_dver'][build_dver]  # modified in-place!
+        targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
+        targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
+
     vcs_module = None
 
-    if task in ['koji', 'mock']:
-        for build_dver in buildopts['enabled_dvers']:
-            if kojiinter:
-                targetopts = buildopts['targetopts_by_dver'][build_dver]  # modified in-place!
-                targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
-                targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
-    # checks
-    if task == 'koji' and buildopts['want_vcs']:
-        # verify working dirs
-        for pkg in package_dirs:
+    #
+    # Verify package dirs
+    #
+
+    for pkg in package_dirs:
+        if buildopts['want_vcs']:
+            # verify working dirs
             # vcs_module is the module for accessing the repo
             vcs_module = svn if svn.is_svn(pkg) else git if git.is_git(pkg) else None
             if not vcs_module:
@@ -76,24 +79,69 @@ def main(argv=None):
 
             if not buildopts['scratch']:
                 vcs_module.verify_correct_branch(pkg, buildopts)
-    else:
-        # verify package dirs
-        for pkg in package_dirs:
-            if not os.path.isdir(pkg):
-                raise UsageError(pkg + " isn't a directory!")
-            if ((not os.path.isdir(os.path.join(pkg, "osg"))) and
-                    (not os.path.isdir(os.path.join(pkg, "upstream")))):
-                raise UsageError(pkg +
-                    " isn't a package directory "
-                    "(must have either osg/ or upstream/ dirs or both)")
+        else:
+            is_pkg_dir(pkg)
 
-    if task == 'koji' and len(package_dirs) >= BACKGROUND_THRESHOLD:
-        buildopts['background'] = True
+    #
+    # Main loop
+    #
 
-    # main loop
-    # HACK
     task_ids = []
     task_ids_by_results_dir = dict()
+
+    for pkg in package_dirs:
+        log.info("Performing task koji on package %s", pkg if utils.is_url(pkg) else os.path.basename(pkg))
+        for build_dver in buildopts['enabled_dvers']:
+            dver_buildopts = buildopts.copy()
+            dver_buildopts.update(buildopts['targetopts_by_dver'][build_dver])
+
+            koji_obj = kojiinter.KojiInter(dver_buildopts)
+
+            if buildopts['want_vcs']:
+                assert vcs_module
+                task_ids.append(vcs_module.koji(pkg, koji_obj, dver_buildopts))
+            else:
+                builder = srpm.SRPMBuild(
+                    pkg,
+                    dver_buildopts,
+                    mock_obj=None,
+                    koji_obj=koji_obj
+                )
+                builder.clean_previous()
+                task_ids_by_results_dir.setdefault(builder.results_dir, [])
+                task_id = builder.koji()
+                task_ids.append(task_id)
+                task_ids_by_results_dir[builder.results_dir].append(task_id)
+
+    #
+    # End of main loop
+    #
+
+    return watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir)
+
+
+def main(argv=None):
+    """Main function."""
+    if argv is None:
+        argv = sys.argv
+
+    buildopts, package_dirs, task = init(argv)
+
+    if task == "koji":
+        return koji_main(buildopts, package_dirs)
+
+    if task == "mock":
+        for build_dver in buildopts['enabled_dvers']:
+            if kojiinter:
+                targetopts = buildopts['targetopts_by_dver'][build_dver]  # modified in-place!
+                targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
+                targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
+
+    # verify package dirs
+    for pkg in package_dirs:
+        is_pkg_dir(pkg)
+
+    # main loop
     for pkg in package_dirs:
         log.info("Performing task %s on package %s", task, pkg if utils.is_url(pkg) else os.path.basename(pkg))
         for build_dver in buildopts['enabled_dvers']:
@@ -102,9 +150,6 @@ def main(argv=None):
 
             mock_obj = None
             koji_obj = None
-            if task == 'koji':
-                assert kojiinter  # shouldn't get here without osg-build-koji
-                koji_obj = kojiinter.KojiInter(dver_buildopts)
             if task == 'mock':
                 assert mock  # shouldn't get here without osg-build-mock
                 if dver_buildopts['mock_config_from_koji']:
@@ -115,23 +160,20 @@ def main(argv=None):
                     koji_obj = kojiinter.KojiInter(dver_buildopts_)
                 mock_obj = mock.Mock(dver_buildopts, koji_obj)
 
-            if buildopts['want_vcs'] and task == 'koji':
-                task_ids.append(vcs_module.koji(pkg, koji_obj, dver_buildopts))
-            else:
-                builder = srpm.SRPMBuild(pkg,
-                                         dver_buildopts,
-                                         mock_obj=mock_obj,
-                                         koji_obj=koji_obj)
-                builder.clean_previous()
-                method = getattr(builder, task)
-                if task == 'koji':
-                    task_ids_by_results_dir.setdefault(builder.results_dir, [])
-                    task_id = method()
-                    task_ids.append(task_id)
-                    task_ids_by_results_dir[builder.results_dir].append(task_id)
-                else:
-                    method()
+            builder = srpm.SRPMBuild(pkg,
+                                     dver_buildopts,
+                                     mock_obj=mock_obj,
+                                     koji_obj=koji_obj)
+            builder.clean_previous()
+            method = getattr(builder, task)
+            method()
     # end of main loop
+
+    return 0
+
+
+def watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir):
+    # TODO Document
     # HACK
     task_ids = sorted(filter(None, task_ids))
     if kojiinter and kojiinter.KojiInter.backend and task_ids:
@@ -142,18 +184,29 @@ def main(argv=None):
         print("Koji task ids are:", task_ids)
         for tid in task_ids:
             print(koji_weburl + "/taskinfo?taskID=" + str(tid))
-        if not buildopts['no_wait']:
-            ret = kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
-            if buildopts['getfiles']:
-                for destdir, tids in task_ids_by_results_dir.items():
-                    if kojiinter.KojiInter.backend.download_results(tids, destdir):
-                        log.info("Results and logs downloaded to %s", destdir)
-            try:
-                return int(ret)
-            except (TypeError, ValueError):
-                pass
+        if buildopts["no_wait"]:
+            return 0
+    ret = kojiinter.KojiInter.backend.watch_tasks_with_retry(task_ids)
+    if buildopts['getfiles']:
+        for destdir, tids in task_ids_by_results_dir.items():
+            if kojiinter.KojiInter.backend.download_results(tids, destdir):
+                log.info("Results and logs downloaded to %s", destdir)
+    try:
+        return int(ret)
+    except (TypeError, ValueError):
+        pass
 
-    return 0
+
+def is_pkg_dir(pkg):
+    if not os.path.isdir(pkg):
+        raise UsageError(pkg + " isn't a directory!")
+    if ((not os.path.isdir(os.path.join(pkg, "osg"))) and
+            (not os.path.isdir(os.path.join(pkg, "upstream")))):
+        raise UsageError(pkg +
+                         " isn't a package directory "
+                         "(must have either osg/ or upstream/ dirs or both)")
+
+
 # end of main()
 
 
@@ -190,6 +243,9 @@ def init(argv):
     if not package_dirs:
         guess = guess_pkg_dir(os.getcwd())
         package_dirs.append(guess)
+
+    if len(package_dirs) >= BACKGROUND_THRESHOLD:
+        buildopts["background"] = True
 
     return (buildopts, package_dirs, task)
 # end of init()

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -487,16 +487,6 @@ rpmbuild     Build using rpmbuild(8) on the local machine
             help="Do not build package directly from SVN/Git "
             "(default for scratch builds)")
         koji_group.add_option(
-            "--3.5-upcoming", action="callback",
-            callback=parser_targetopts_callback,
-            type=None,
-            help="Target build for the 3.5-upcoming osg repos.")
-        koji_group.add_option(
-            "--3.6-upcoming", action="callback",
-            callback=parser_targetopts_callback,
-            type=None,
-            help="Target build for the 3.6-upcoming osg repos.")
-        koji_group.add_option(
             "--repo", action="callback",
             callback=parser_targetopts_callback,
             type="string", dest="repo",
@@ -551,7 +541,7 @@ def parser_targetopts_callback(option, opt_str, value, parser, *args, **kwargs):
     --koji-tag=el7-foobar will implicitly turn on el7 builds.
 
     Also handle --ktt (--koji-tag-and-target), which sets both koji_tag
-    and koji_target, and --upcoming, and --repo, which sets the target for both dvers.
+    and koji_target, and --repo, which sets the target for both dvers.
 
     """
     # for options that have aliases, option.dest gives us the
@@ -587,13 +577,6 @@ def parser_targetopts_callback(option, opt_str, value, parser, *args, **kwargs):
         assert kojiinter  # shouldn't get here without kojiinter
         for dver in targetopts_by_dver:
             targetopts_by_dver[dver]['koji_tag'] = 'TARGET'
-    elif opt_str.endswith('upcoming'):
-        assert kojiinter  # shouldn't get here without kojiinter
-        repo = opt_str[2:]
-        parser.values.repo = repo
-        for dver in DVERS:
-            targetopts_by_dver[dver]['koji_target'] = target_for_repo_hint(repo, dver)
-            targetopts_by_dver[dver]['koji_tag'] = tag_for_repo_hint(repo, dver)
     elif opt_str == '--repo':
         assert kojiinter  # shouldn't get here without kojiinter
         parser.values.repo = value
@@ -708,7 +691,7 @@ def get_buildopts(options, task):
                 buildopts['enabled_dvers'] = set(DEFAULT_DVERS)
         else:
             machine_dver = utils.get_local_machine_dver() or FALLBACK_DVER
-            buildopts['enabled_dvers'] = set([machine_dver])
+            buildopts['enabled_dvers'] = {machine_dver}
 
     # Hack: make --mock-config on command line override
     # --mock-config-from-koji from config file

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -51,8 +51,8 @@ def main(argv=None):
 
     if task in ['koji', 'mock']:
         for build_dver in buildopts['enabled_dvers']:
-            targetopts = buildopts['targetopts_by_dver'][build_dver]
             if kojiinter:
+                targetopts = buildopts['targetopts_by_dver'][build_dver]  # modified in-place!
                 targetopts['koji_target'] = targetopts['koji_target'] or target_for_repo_hint(buildopts['repo'], build_dver)
                 targetopts['koji_tag'] = targetopts['koji_tag'] or tag_for_repo_hint(buildopts['repo'], build_dver)
     # checks
@@ -229,7 +229,7 @@ def valid_dvers(targets):
     targets: a list of koji targets returned by valid_koji_targets"""
     dvers = set()
     for target in targets:
-        dver = get_dver_from_string(target)
+        dver = utils.get_dver_from_string(target)
         if dver:
             dvers.add(dver)
     return sorted(dvers)
@@ -576,7 +576,7 @@ def parser_targetopts_callback(option, opt_str, value, parser, *args, **kwargs):
             targetopts_by_dver[dver]['koji_target'] = target_for_repo_hint(value, dver)
             targetopts_by_dver[dver]['koji_tag'] = tag_for_repo_hint(value, dver)
     else:
-        dver = get_dver_from_string(value)
+        dver = utils.get_dver_from_string(value)
 
         if not dver:
             raise OptionValueError('Unable to determine redhat release in parameter %r: %r' % (opt_str, value))
@@ -685,15 +685,6 @@ def get_buildopts(options, task):
             machine_dver = utils.get_local_machine_dver() or FALLBACK_DVER
             buildopts['enabled_dvers'] = {machine_dver}
 
-    # Hack: make --mock-config on command line override
-    # --mock-config-from-koji from config file
-    if getattr(options, 'mock_config', None) is not None:
-        buildopts['mock_config_from_koji'] = None
-
-    # If set, --mock-config-from-koji overrides --mock-config
-    if buildopts.get('mock_config_from_koji', None):
-        buildopts['mock_config'] = None
-
     if kojiinter and buildopts['vcs'] is None and task == 'koji':
         if buildopts['scratch']:
             buildopts['vcs'] = False
@@ -747,9 +738,9 @@ def verify_release_in_targetopts_by_dver(targetopts_by_dver):
         return all((same_or_none2(args[x], args[y]) for x in range(len(args)) for y in range(x, len(args))))
 
     # Verify consistency
-    dist_dver = get_dver_from_string(distro_tag)
-    target_dver = get_dver_from_string(koji_target)
-    tag_dver = get_dver_from_string(koji_tag)
+    dist_dver = utils.get_dver_from_string(distro_tag)
+    target_dver = utils.get_dver_from_string(koji_target)
+    tag_dver = utils.get_dver_from_string(koji_tag)
 
     if not same_or_none(dver, dist_dver, tag_dver, target_dver):
         return None

--- a/osgbuild/srpm.py
+++ b/osgbuild/srpm.py
@@ -59,16 +59,15 @@ class SRPMBuild(object):
     # end of __init__()
 
 
-    def maybe_autoclean(self):
-        """Delete underscore directories if the autoclean option is set."""
-        if self.buildopts['autoclean']:
-            for udir in [self.results_dir,
-                         self.prebuild_dir,
-                         self.unpacked_dir,
-                         self.unpacked_tarball_dir]:
-                if os.path.exists(udir):
-                    log.debug("autoclean removing " + udir)
-                    shutil.rmtree(udir)
+    def clean_previous(self):
+        """Delete underscore directories."""
+        for udir in [self.results_dir,
+                     self.prebuild_dir,
+                     self.unpacked_dir,
+                     self.unpacked_tarball_dir]:
+            if os.path.exists(udir):
+                log.debug("clean_previous removing " + udir)
+                shutil.rmtree(udir)
 
 
     def get_rpmbuild_defines(self, prebuild):
@@ -183,10 +182,9 @@ class SRPMBuild(object):
         if not utils.which("quilt"):
             raise ProgramNotFoundError("quilt")
 
-        if self.buildopts['autoclean']:
-            if os.path.exists(self.quilt_dir):
-                log.debug("autoclean removing " + self.quilt_dir)
-                shutil.rmtree(self.quilt_dir)
+        if os.path.exists(self.quilt_dir):
+            log.debug("removing previous" + self.quilt_dir)
+            shutil.rmtree(self.quilt_dir)
 
         utils.safe_makedirs(self.quilt_dir)
         spec_filename = self.prebuild_external_sources(destdir=self.quilt_dir)

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -4,7 +4,7 @@ import os
 import errno
 
 from .constants import SVN_ROOT, SVN_REDHAT_PATH, SVN_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
-from .error import Error, SVNError, UsageError
+from .error import Error, VCSError, UsageError
 from . import utils
 
 
@@ -44,7 +44,7 @@ def is_uncommitted(package_dir):
         return False
     out, err = utils.sbacktick("svn status -q " + package_dir, err2out=True)
     if err:
-        raise SVNError("Exit code %d getting SVN status. Output:\n%s" % (err, out))
+        raise VCSError("Exit code %d getting SVN status. Output:\n%s" % (err, out))
     if out:
         print("The following uncommitted changes exist:")
         print(out)
@@ -62,7 +62,7 @@ def is_outdated(package_dir):
         return False
     out, err = utils.sbacktick("svn status -u -q " + package_dir)
     if err:
-        raise SVNError("Exit code %d getting SVN status. Output:\n%s" % (err, out))
+        raise VCSError("Exit code %d getting SVN status. Output:\n%s" % (err, out))
     outdated_files = []
     for line in out.split("\n"):
         try:
@@ -109,7 +109,7 @@ def verify_package_info(package_info):
     command = ["svn", "ls", url, "-r", rev]
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise SVNError("Exit code %d getting SVN listing of %s (rev %s). Output:\n%s" % (err, url, rev, out))
+        raise VCSError("Exit code %d getting SVN listing of %s (rev %s). Output:\n%s" % (err, url, rev, out))
     for line in out.split("\n"):
         if line.startswith('osg/') or line.startswith('upstream/'):
             return True
@@ -205,9 +205,9 @@ def verify_correct_branch(package_dir, buildopts):
     url = package_info['canon_url']
     # Check for old, deprecated branches
     if SVN_REDHAT_PATH + '/trunk/' in url:
-        raise SVNError("trunk has been removed; use branches/osg-3.5 instead")
+        raise VCSError("trunk has been removed; use branches/osg-3.5 instead")
     elif SVN_REDHAT_PATH + '/branches/upcoming/' in url:
-        raise SVNError("unversioned upcoming has been removed; use branches/3.5-upcoming instead")
+        raise VCSError("unversioned upcoming has been removed; use branches/3.5-upcoming instead")
     branch_match = re.search(SVN_REDHAT_PATH + r'/(branches/[^/]+)/', url)
     if not branch_match:
         # Building from a weird path (such as a tag). Be permissive -- koji
@@ -223,7 +223,7 @@ def verify_correct_branch(package_dir, buildopts):
             # Some custom target -- any branch ok
             continue
         if not restricted_branch_matches_target(branch, target):
-            raise SVNError("Forbidden to build from %s branch into %s target" % (branch, target))
+            raise VCSError("Forbidden to build from %s branch into %s target" % (branch, target))
 
 
 def get_package_info(package_dir):
@@ -237,7 +237,7 @@ def get_package_info(package_dir):
 
     out, err = utils.sbacktick(command, err2out=True)
     if err:
-        raise SVNError("Exit code %d getting SVN info. Output:\n%s" % (err, out))
+        raise VCSError("Exit code %d getting SVN info. Output:\n%s" % (err, out))
     info = dict()
     for line in out.split("\n"):
         label, value = line.strip().split(": ", 1)

--- a/osgbuild/utils.py
+++ b/osgbuild/utils.py
@@ -624,3 +624,15 @@ def split_nvr(build):
         return match.group('name'), match.group('version'), match.group('release')
     else:
         return '', '', ''
+
+
+def get_dver_from_string(s):
+    """Get the EL major version from a string containing it.
+    Return None if not found."""
+    if not s:
+        return None
+    match = re.search(r'\b(el\d+)\b', s)
+    if match is not None:
+        return match.group(1)
+    else:
+        return None


### PR DESCRIPTION
Cleanup of main module.  User-visible changes:

* removed --autoclean and --no-autoclean arguments; temporary directories are always cleaned
* removed the -w (--working-directory) argument; temp files and build results are always written to subdirs under the package directory
* removed the --3.5-upcoming and --3.6-upcoming arguments
* removed the superfluous --no-vcs and --no-svn arguments: scratch builds are not from VCS by default, and non-scratch builds must be from VCS anyway