### PR TITLE
New upstream source area

### DIFF
--- a/fetch-dot-source
+++ b/fetch-dot-source
@@ -7,7 +7,7 @@ import os
 
 from osgbuild.main          import log, log_consolehandler
 from osgbuild.error         import Error
-from osgbuild.fetch_sources import C, process_dot_source
+from osgbuild.fetch_sources import process_dot_source
 
 def usage(exit):
     print("Usage: {script} [-d destdir] [options] upstream.source [...]\n\n"
@@ -27,7 +27,7 @@ def setloglevel(level):
     log_consolehandler.setLevel(level)
 
 options = dict(
-    cache_prefix = C.WEB_CACHE_PREFIX,
+    cache_prefix = None,
     destdir = '.',
     nocheck = False,
     want_spec = False
@@ -46,7 +46,7 @@ for op,val in ops:
     elif op == '-s': options['want_spec'] = True
     elif op == '-d': options['destdir'] = val
     elif op == '-c': options['cache_prefix'] = val
-    elif op == '-a': options['cache_prefix'] = C.AFS_CACHE_PREFIX
+    elif op == '-a': raise Error("AFS cache prefix (-a) not supported anymore")
     elif op == '-v': setloglevel(logging.DEBUG)
     elif op == '-q': setloglevel(logging.WARNING)
     elif op == '-h': usage(0)

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -6,8 +6,6 @@ WD_PREBUILD = '_final_srpm_contents'
 WD_UNPACKED = '_upstream_srpm_contents'
 WD_UNPACKED_TARBALL = '_upstream_tarball_contents'
 WD_QUILT = '_quilt'
-AFS_CACHE_PATH = '/p/vdt/public/html/upstream'
-AFS_CACHE_PREFIX = 'file://' + AFS_CACHE_PATH
 BACKUP_WEB_CACHE_PREFIX = 'https://vdt.cs.wisc.edu/upstream'
 WEB_CACHE_PREFIX = 'https://sw-upstream.svc.osg-htc.org/upstream'
 
@@ -85,7 +83,7 @@ GIT_REMOTE_MAPS = {HCC_AUTH_REMOTE: HCC_REMOTE,
 
 DEFAULT_BUILDOPTS_COMMON = {
     'background': False,
-    'cache_prefix': 'AUTO',
+    'cache_prefix': None,
     'dry_run': False,
     'full_extract': False,
     'getfiles': False,

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -8,7 +8,7 @@ WD_UNPACKED_TARBALL = '_upstream_tarball_contents'
 WD_QUILT = '_quilt'
 AFS_CACHE_PATH = '/p/vdt/public/html/upstream'
 AFS_CACHE_PREFIX = 'file://' + AFS_CACHE_PATH
-# WEB_CACHE_PREFIX = 'https://vdt.cs.wisc.edu/upstream'
+BACKUP_WEB_CACHE_PREFIX = 'https://vdt.cs.wisc.edu/upstream'
 WEB_CACHE_PREFIX = 'https://sw-upstream.svc.osg-htc.org/upstream'
 
 KOJI_USER_CONFIG_DIR = _os.path.expanduser("~/.koji")

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -8,7 +8,8 @@ WD_UNPACKED_TARBALL = '_upstream_tarball_contents'
 WD_QUILT = '_quilt'
 AFS_CACHE_PATH = '/p/vdt/public/html/upstream'
 AFS_CACHE_PREFIX = 'file://' + AFS_CACHE_PATH
-WEB_CACHE_PREFIX = 'https://vdt.cs.wisc.edu/upstream'
+# WEB_CACHE_PREFIX = 'https://vdt.cs.wisc.edu/upstream'
+WEB_CACHE_PREFIX = 'https://sw-upstream.svc.osg-htc.org/upstream'
 
 KOJI_USER_CONFIG_DIR = _os.path.expanduser("~/.koji")
 OSG_KOJI_USER_CONFIG_DIR = _os.path.expanduser("~/.osg-koji")

--- a/osgbuild/fetch_sources.py
+++ b/osgbuild/fetch_sources.py
@@ -89,6 +89,23 @@ FetchOptions = collections.namedtuple('FetchOptions',
     ['destdir', 'cache_prefix', 'nocheck', 'want_spec']
 )
 
+
+class CouldNotDownload(Error):
+    """Raised when we could not download the file from the remote server."""
+
+
+class CouldNotSave(Error):
+    """Raised when we could not save the downloaded file to the local disk."""
+
+
+class SourceLineError(Error):
+    """Raised when there is a syntax or usage error in the .source line."""
+
+
+class ChecksumMismatch(Error):
+    """Raised when the checksum of a downloaded file does not match the expected value."""
+
+
 # fetch handlers are defined like:
 #
 #   fetch_xyz_source(
@@ -101,8 +118,25 @@ FetchOptions = collections.namedtuple('FetchOptions',
 
 
 def fetch_cached_source(relpath, sha1sum=None, ops=None):
-    uri = os.path.join(ops.cache_prefix, relpath)
-    return fetch_uri_source(uri, sha1sum, ops=ops)
+    if ops.cache_prefix is not None:
+        # cache_prefix explicitly specified, download from there
+        uri = os.path.join(ops.cache_prefix, relpath)
+        return fetch_uri_source(uri, sha1sum, ops=ops)
+    else:
+        # cache prefix not specified -- try the primary, then fall back to the backup
+        primary_uri = os.path.join(C.WEB_CACHE_PREFIX, relpath)
+        backup_uri = os.path.join(C.BACKUP_WEB_CACHE_PREFIX, relpath)
+        try:
+            return fetch_uri_source(primary_uri, sha1sum, ops=ops)
+        except CouldNotDownload as err:
+            # Couldn't download -- 404?  We can try the backup URI.
+            # (If we could download but not save, finding another source wouldn't help)
+            log.warning(
+                "Could not download from primary cache URI %s; trying backup %s. "
+                "Error was: %s",
+                primary_uri, backup_uri, err
+            )
+            return fetch_uri_source(backup_uri, sha1sum, ops=ops)
 
 
 def fetch_uri_source(uri, sha1sum=None, ops=None, filename=None):
@@ -125,7 +159,7 @@ def download_uri(uri, outfile):
     try:
         handle = urllib.request.urlopen(uri)
     except urllib.error.URLError as err:
-        raise Error("Unable to download %s\n%s" % (uri, err))
+        raise CouldNotDownload("Unable to download %s\n%s" % (uri, err))
 
     sha = hashlib.sha1()
     try:
@@ -134,7 +168,7 @@ def download_uri(uri, outfile):
                 desthandle.write(chunk)
                 sha.update(chunk)
     except EnvironmentError as e:
-        raise Error("Unable to save downloaded file to %s\n%s" % (outfile, e))
+        raise CouldNotSave("Unable to save downloaded file to %s\n%s" % (outfile, e))
     return sha.hexdigest()
 
 
@@ -153,12 +187,12 @@ def check_file_checksum(path, sha1sum, got_sha1sum, nocheck):
         if nocheck:
             log.warning(msg + "\n    (ignored)")
         else:
-            raise Error(msg)
+            raise ChecksumMismatch(msg)
 
 
 def _required(item, key):
     if item is None:
-        raise Error("No '%s' specified" % key)
+        raise SourceLineError("No '%s' specified" % key)
 
 
 def _almost_required(item, key):
@@ -170,7 +204,7 @@ def _almost_required(item, key):
 def _mk_prefix(name, tag, tarball):
     if tarball:
         if not tarball.endswith('.tar.gz'):
-            raise Error("tarball must end with .tar.gz: '%s'" % tarball)
+            raise SourceLineError("tarball must end with .tar.gz: '%s'" % tarball)
         prefix = tarball[:-len('.tar.gz')]
     else:
         tag = os.path.basename(tag)
@@ -184,7 +218,7 @@ def _mk_prefix(name, tag, tarball):
 def fetch_github_source(repo, tag, hash=None, ops=None, **kw):
     m = re.match(r"([^\s/]+)/([^\s/]+?)(?:.git)?$", repo)
     if not m:
-        raise Error("'repo' syntax for type=github must be owner/project")
+        raise SourceLineError("'repo' syntax for type=github must be owner/project")
     url = "https://github.com/" + repo
     return fetch_git_source(url, tag, hash, ops=ops, **kw)
 
@@ -253,7 +287,7 @@ def git_archive_remote_ref(
             checked_call2(['git', 'clone', '--branch', tag, url, '.'])
     except CalledProcessError as e:
         log.error("Failed to retrieve tag '%s' from repo '%s'" % (tag, url))
-        raise Error(e)
+        raise CouldNotDownload(e)
 
     got_sha = utils.checked_backtick(['git', 'rev-parse', 'HEAD'])
     if hash or not ops.nocheck:
@@ -308,7 +342,7 @@ def check_git_hash(url, tag, sha, got_sha, nocheck):
         if nocheck:
             log.warning(msg + "\n    (ignored)")
         else:
-            raise Error(msg)
+            raise ChecksumMismatch(msg)
 
 
 def deref_git_sha(sha):
@@ -340,15 +374,16 @@ def process_source_line(line, ops):
         except TypeError as e:
             fancy_source_error(meta_type, explicit_type, handler, args, kv, e)
     else:
-        raise Error("Unrecognized type '%s' (valid types are: %s)"
-                    % (meta_type, sorted(handlers)))
+        raise SourceLineError(
+            "Unrecognized type '%s' (valid types are: %s)" % (meta_type, sorted(handlers))
+        )
 
 
 def get_auto_source_type(*args, **kw):
     if not args:
-        raise Error("No type specified and no default arg provided")
+        raise SourceLineError("No type specified and no default arg provided")
     if args[0].endswith('.git'):
-        raise Error("No automatic types allowed for git sources")
+        raise SourceLineError("No automatic types allowed for git sources")
     if re.search(r'^\w+://', args[0]) or args[0].startswith('/'):
         return 'uri'
     else:
@@ -410,7 +445,7 @@ def fancy_source_error(meta_type, explicit_type, handler, args, kw, e):
         log.error("Provided too many positional arguments: %s" % ' '.join(args))
     else:
         log.error(e)
-    raise Error("Invalid parameters for %s=%s source line" % (xtype,meta_type))
+    raise SourceLineError("Invalid parameters for %s=%s source line" % (xtype,meta_type))
 
 
 def process_dot_source(cache_prefix, sfilename, destdir, nocheck, want_spec):
@@ -481,7 +516,7 @@ def copy_with_filter(files_list, destdir):
 
 def fetch(package_dir,
           destdir=None,
-          cache_prefix=C.WEB_CACHE_PREFIX,
+          cache_prefix=None,
           unpacked_dir=None,
           want_full_extract=False,
           unpacked_tarball_dir=None,

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -394,10 +394,8 @@ rpmbuild     Build using rpmbuild(8) on the local machine
     parser = OptionParser(header)
     parser.add_option(
         "-c", "--cache-prefix",
-        help="The prefix for the software cache to take source files from. "
-        "The following special caches exist: "
-        "AFS (%s), VDT (%s), and AUTO (AFS if avaliable, VDT if not). "
-        "Default: AUTO" % (AFS_CACHE_PREFIX, WEB_CACHE_PREFIX))
+        help="The prefix for the software cache to take source files from."
+    )
     for dver in DVERS:
         rhel = int(dver[2:])
         parser.add_option(
@@ -701,16 +699,10 @@ def get_buildopts(options, task):
         buildopts['working_directory'] = (tempfile.mkdtemp(prefix='osg-build-'))
         log.debug('Working directory is %s', buildopts['working_directory'])
 
-    # Special case for cache_prefix being AFS or VDT
-    if buildopts['cache_prefix'].upper() == 'AFS':
-        buildopts['cache_prefix'] = AFS_CACHE_PREFIX
-    elif buildopts['cache_prefix'].upper() == 'VDT':
-        buildopts['cache_prefix'] = WEB_CACHE_PREFIX
-    elif buildopts['cache_prefix'].upper() == 'AUTO':
-        if os.path.exists(AFS_CACHE_PATH):
-            buildopts['cache_prefix'] = AFS_CACHE_PREFIX
-        else:
-            buildopts['cache_prefix'] = WEB_CACHE_PREFIX
+    # Always use the web cache (primary or backup) unless otherwise specified.
+    # Backward compat for old special values:
+    if str(buildopts['cache_prefix']).upper() in {'AFS', 'VDT', 'AUTO', "NONE"}:
+        buildopts['cache_prefix'] = None
 
     # If nothing has set targetopts_by_dver, set it here
     if not buildopts.get('targetopts_by_dver', None):


### PR DESCRIPTION
This changes the source file download code to download from the new upstream area, https://sw-upstream.svc.osg-htc.org , falling back to https://vdt.cs.wisc.edu if the download fails (since the new upstream area may not have the sources people just uploaded).

Relatedly, this removes the ability to use the `/p/vdt/public/html/upstream` directory directly as the cache prefix; instead, the sources are always downloaded from HTTP.