### PR TITLE
Git-based packaging workflow and making --repo optional

### DIFF
--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -17,6 +17,7 @@ DATA_DIR = "/usr/share/osg-build"
 PROMOTER_INI = 'promoter.ini'
 SIGNING_KEYS_INI = 'signing_keys.ini'
 DEFAULT_AUTHTYPE = "kerberos"
+LOCAL_KOJI_INI = "koji.ini"
 
 KOJI_HUB = "https://koji.osg-htc.org"
 KOJI_WEB = "https://koji.osg-htc.org"

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -27,6 +27,7 @@ if "OSG_LOCATION" in _os.environ:
 DATA_FILE_SEARCH_PATH.append(DATA_DIR)
 try:
     try:
+        # noinspection PyPackageRequirements
         import importlib_resources as _importlib_resources
     except ImportError:
         import importlib.resources as _importlib_resources
@@ -34,52 +35,6 @@ try:
 except (ImportError, AttributeError):
     pass
 
-# fmt: off
-SVN_RESTRICTED_BRANCHES = {
-    r'^branches/(?P<osgver>[0-9.]+)-upcoming$'  : 'upcoming',
-    r'^branches/osg-internal$'                  : 'oldinternal',
-    r'^branches/devops$'                        : 'devops',
-    r'^branches/osg-(?P<osgver>\d+\.\d+)$'      : 'versioned',
-    r'^branches/(?P<osgver>[0-9.]+)-main$'      : 'versioned',
-    r'^branches/(?P<osgver>[0-9.]+)-internal$'  : 'internal',
-}
-KOJI_RESTRICTED_TARGETS = {
-    r'^osg-(el\d+)$'                                : 'main',
-    r'^osg-(?P<osgver>[0-9.]+)-upcoming-(el\d+)$'   : 'upcoming',
-    r'^devops-(el\d+)$'                             : 'devops',
-    r'^osg-(el\d+)-internal$'                       : 'oldinternal',
-    r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'           : 'versioned',
-    r'^osg-(?P<osgver>[0-9.]+)-main-(el\d+)$'       : 'versioned',
-    r'^osg-(?P<osgver>[0-9.]+)-internal-(el\d+)$'   : 'internal',
-    r'^chtc-(el\d+)$'                               : 'chtc',
-}
-GIT_RESTRICTED_BRANCHES = {
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-upcoming$'    : 'upcoming',
-    r'^(\w*/)?internal$'                        : 'oldinternal',
-    r'^(\w*/)?devops$'                          : 'devops',
-    r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'        : 'versioned',
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-main$'        : 'versioned',
-    r'^(\w*/)?(?P<osgver>[0-9.]+)-internal$'    : 'internal',
-}
-# fmt: on
-
-OSG_REMOTE = 'https://github.com/opensciencegrid/Software-Redhat.git'
-OSG_AUTH_REMOTE = 'git@github.com:opensciencegrid/Software-Redhat.git'
-HCC_REMOTE = 'https://github.com/unlhcc/hcc-packaging.git'
-HCC_AUTH_REMOTE = 'git@github.com:unlhcc/hcc-packaging.git'
-CHTC_REMOTE = 'https://github.com/CHTC/packaging.git'
-CHTC_AUTH_REMOTE = 'git@github.com:CHTC/packaging.git'
-
-KNOWN_GIT_REMOTES = [HCC_REMOTE,
-                     HCC_AUTH_REMOTE,
-                     OSG_REMOTE,
-                     OSG_AUTH_REMOTE,
-                     CHTC_REMOTE,
-                     CHTC_AUTH_REMOTE]
-# Map the authenticated URL to an anonymous checkout URL.
-GIT_REMOTE_MAPS = {HCC_AUTH_REMOTE: HCC_REMOTE,
-                   OSG_AUTH_REMOTE: OSG_REMOTE,
-                   CHTC_AUTH_REMOTE: CHTC_REMOTE}
 
 DEFAULT_BUILDOPTS_COMMON = {
     'background': False,

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -86,12 +86,6 @@ DEFAULT_DVERS_BY_REPO = {
     'devops': ['el7', 'el8', 'el9'],
     'chtc': ['el9'],
 }
-assert FALLBACK_DVER in DVERS
-for _d in DEFAULT_DVERS:
-    assert _d in DVERS
-for _ds in DEFAULT_DVERS_BY_REPO.values():
-    for _d in _ds:
-        assert _d in DVERS
 
 REPO_HINTS_STATIC = {
     'devops': {'target': 'devops-%(dver)s', 'tag': 'osg-%(dver)s'},

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -190,7 +190,7 @@ def get_known_remote(package_dir):
         remote_url = _normalize_remote(info[1])
         if remote_url in REMOTES_BY_URL:
             return remote_name, remote_url
-    raise VCSError("Known remote not found for directory %s; are URLs configurated correctly?" % package_dir)
+    raise VCSError("Known remote not found for directory %s; are URLs configured correctly?" % package_dir)
 
 
 def get_fetch_url(package_dir, remote):

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -313,23 +313,24 @@ def is_outdated(package_dir):
     return True
 
 
-def verify_working_dir(pkg):
+def verify_working_dir(pkg) -> None:
     """Verify if a package working directory has uncommitted changes or is
-    outdated and ask the user what to do. Return True if it's ok to continue.
+    outdated and ask the user what to do.
 
+    Raises VCSError if there is an issue and the user chooses not to continue.
     """
     if is_uncommitted(pkg):
         if not utils.ask_yn("""\
 Package working directory %s has uncommitted changes that will not be included
 in the git build.
 Continue (yes/no)?""" % pkg):
-            return False
+            raise VCSError("Package working directory %s has uncommitted changes." % pkg)
     if is_outdated(pkg):
         if not utils.ask_yn("""\
 Package working directory %s is out of date and its contents may not reflect
 what will be built.
 Continue (yes/no)?""" % pkg):
-            return False
+            raise VCSError("Package working directory %s is out of date." % pkg)
     return True
 
 

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -4,6 +4,7 @@ import pathlib
 import re
 import os
 import errno
+import typing as t
 from urllib.parse import urlsplit
 
 from .error import Error, UsageError, VCSError
@@ -366,7 +367,10 @@ def verify_correct_remote(package_dir):
         raise VCSError("Remote %s for directory %s is not an officially known remote." % (remote, package_dir))
 
 
-def verify_correct_branch(package_dir, buildopts):
+def verify_correct_branch(
+        package_dir,
+        koji_targets: t.Sequence[str],
+):
     """Check that the user is not trying to build from trunk into upcoming, or
     vice versa.
     """
@@ -384,14 +388,10 @@ def verify_correct_branch(package_dir, buildopts):
         if remote in REMOTES["osg"].urls:
             verify_git_svn_commit(package_dir)
 
-    assert buildopts['enabled_dvers'], "No enabled dvers -- catch this sooner"
-    enabled_dvers = sorted(buildopts['enabled_dvers'])
     _log.debug("found remote %s", remote)
-    for dver in enabled_dvers:
-        koji_target = buildopts['targetopts_by_dver'][dver]['koji_target']
-        if not koji_target:
-            _log.debug(f"No koji target for {dver} -- skipping VCS check")
-            continue
+    if isinstance(koji_targets, str):
+        koji_targets = [koji_targets]
+    for koji_target in koji_targets:
         for rt in RESTRICTED_TARGETS.values():
             target_match = rt.koji_target_re.fullmatch(koji_target)
             if not target_match:

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -1,31 +1,41 @@
 """Helper functions for a git build."""
 import logging
+import pathlib
 import re
 import os
 import errno
 from urllib.parse import urlsplit
 
-
-from .constants import GIT_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
-from .error import Error, VCSError
+from .error import Error, UsageError, VCSError
+from .target_protection import RESTRICTED_TARGETS, RemoteLayout, REMOTES
 from . import utils
-from . import constants
-
+from . import kojiinter
 
 
 _log = logging.getLogger(__name__)
 
+REMOTES_BY_URL = {}
+for k, v in REMOTES.items():
+    for url in v.urls:
+        REMOTES_BY_URL[url] = v
 
-def git_cmd(top_dir, *args):
+# Map the authenticated URL to an anonymous checkout URL.
+GIT_REMOTE_MAPS = {
+    # flatten list of dicts
+    k: v for r in REMOTES.values() for k, v in r.remote_map.items()
+}
+
+
+def git_cmd(run_dir, *args):
     # type: (str, *str) -> list
     """A list of params for doing a git command in a specific repo directory"""
-    return ["git", "-C", top_dir] + list(args)
+    return ["git", "-C", run_dir] + list(args)
 
 
-def run_git_cmd(top_dir, *args):
+def run_git_cmd(run_dir, *args):
     # type: (str, *str) -> tuple[str, int]
     """Run a git command and return its stdout+stderr, and exit code"""
-    command = git_cmd(top_dir, *args)
+    command = git_cmd(run_dir, *args)
     return utils.sbacktick(command, err2out=True)
 
 
@@ -126,78 +136,11 @@ def parse_git_url(git_url):
 # name.
 #
 
-def is_restricted_branch(branch):
-    """branch is a git branch such as 'osg-3.6' or 'devops'.
-    Allows for an optional word as an extra path component on the left.
 
-    """
-    for pattern in GIT_RESTRICTED_BRANCHES:
-        if re.search(pattern, branch):
-            return True
-    return False
-
-
-def is_restricted_target(target):
-    """target is a koji target such as 'osg-el6' or 'osg-3.6-el8'.
-    Assumes no extra characters on either side.
-
-    """
-    for pattern in KOJI_RESTRICTED_TARGETS:
-        if re.search(pattern, target):
-            return True
-    return False
-
-
-def restricted_branch_matches_target(branch, target):
-    """Return True if the pattern that matches `branch` is associated with the
-    same name (e.g. 'devops', 'main', 'upcoming', 'versioned') as the pattern that
-    matches `target`; False otherwise.
-    Special cases:
-    - if the name is 'versioned' (e.g. we're building from 'branches/osg-3.1') then the versions also have to match.
-    - treat 'main' (i.e. 'trunk') as 'versioned' with a version of '3.5'
-    - if the name is 'upcoming' (e.g. building from 'branches/3.6-upcoming') then the versions also have to match.
-      treat a missing version ('branches/upcoming') as '3.5'
-
-    Precondition: is_restricted_branch(branch) and is_restricted_target(target)
-    are True.
-
-    """
-    branch_match = branch_name = target_match = target_name = None
-    for (branch_pattern, branch_name) in GIT_RESTRICTED_BRANCHES.items():
-        branch_match = re.search(branch_pattern, branch)
-        if branch_match:
-            break
-    assert branch_match, \
-            "No GIT_RESTRICTED_BRANCHES pattern matching %s -- is_restricted_branch() should have caught this" % branch
-
-    for (target_pattern, target_name) in KOJI_RESTRICTED_TARGETS.items():
-        target_match = re.search(target_pattern, target)
-        if target_match:
-            break
-    assert target_match, \
-            "No KOJI_RESTRICTED_TARGETS pattern matching %s -- is_restricted_target() should have caught this" % target
-
-    # At this point branch_name should be one of the values (right-hand side) of
-    # GIT_RESTRICTED_BRANCHES, and target_name should be one of the values of
-    # KOJI_RESTRICTED_TARGETS.
-
-    # These might have OSG version numbers ("3.5") in them; make sure they match
-    branch_osgver = branch_match.groupdict().get("osgver", None)
-    target_osgver = target_match.groupdict().get("osgver", None)
-
-    # Deal with "main" (i.e. the "trunk" branch or the "osg-elX" targets), which are aliases for "3.5"
-    if target_name == "main":
-        target_name = "versioned"
-        target_osgver = "3.6"
-
-    # branch_osgver and target_osgver might be None, e.g. for devops but that's OK
-    return (branch_name == target_name) and (branch_osgver == target_osgver)
-
-
-def get_branch(package_dir):
+def get_git_branch(package_dir):
+    # type: (str) -> str
     """Return the current git branch for a given directory."""
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "branch")
+    out, err = run_git_cmd(package_dir, "branch")
     if err:
         raise VCSError("Exit code %d getting git branch for directory %s.  Output:\n%s" % (err, package_dir, out))
     out = out.strip()
@@ -210,13 +153,30 @@ def get_branch(package_dir):
     return branch[0]
 
 
+def get_subtree_branch(package_dir):
+    """
+    Return the branch for the given package directory in a remote using the
+    'subtree' layout.
+
+    Args:
+        package_dir: the package directory to get the branch for
+
+    Returns: the branch name
+    """
+    # The "subtree" layout requires that the package directory be a subdirectory
+    # of the branch.
+    try:
+        return pathlib.Path(package_dir).absolute().parts[-2]
+    except IndexError:
+        raise VCSError("Unable to determine the branch for the package directory %s" % package_dir)
+
+
 def get_known_remote(package_dir):
-    """Return the first remote in the current directory's list of remotes which
-       is on osg-build's configured whitelist of remotes,
+    """Return the first remote in the current directory's list of urls which
+       is on osg-build's configured whitelist of urls,
        as a (name, normalized url) tuple.
        """
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "remote", "-v")
+    out, err = run_git_cmd(package_dir, "remote", "-v")
     if err:
         raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     for line in out.splitlines():
@@ -227,16 +187,15 @@ def get_known_remote(package_dir):
             continue
         remote_name = info[0]
         remote_url = _normalize_remote(info[1])
-        if remote_url in constants.KNOWN_GIT_REMOTES:
+        if remote_url in REMOTES_BY_URL:
             return remote_name, remote_url
-    raise VCSError("Known remote not found for directory %s; are remotes configurated correctly?" % package_dir)
+    raise VCSError("Known remote not found for directory %s; are URLs configurated correctly?" % package_dir)
 
 
 def get_fetch_url(package_dir, remote):
     """Return a fetch url
-       is on osg-build's configured whitelist of remotes."""
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "remote", "-v")
+       is on osg-build's configured whitelist of urls."""
+    out, err = run_git_cmd(package_dir, "remote", "-v")
     if err:
         raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     for line in out.splitlines():
@@ -248,18 +207,17 @@ def get_fetch_url(package_dir, remote):
         dir_remote_name = info[0]
         dir_remote_url = _normalize_remote(info[1])
         if dir_remote_name == remote:
-            return constants.GIT_REMOTE_MAPS.setdefault(dir_remote_url, dir_remote_url)
+            return GIT_REMOTE_MAPS.setdefault(dir_remote_url, dir_remote_url)
             # ^^ mutates a constant, sigh
 
-    raise VCSError("Remote URL not found for remote %s in directory %s; are remotes " \
+    raise VCSError("Remote URL not found for remote %s in directory %s; are urls " \
         "configured correctly?" % (remote, package_dir))
 
 def get_current_branch_remote(package_dir):
     """Return the configured remote name for the current branch."""
-    branch = get_branch(package_dir)
+    branch = get_git_branch(package_dir)
 
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "config", f"branch.{branch}.remote")
+    out, err = run_git_cmd(package_dir, "config", f"branch.{branch}.remote")
     if err:
         raise VCSError("Exit code %d getting git branch %s remote for directory '%s'. Output:\n%s" % \
                        (err, branch, package_dir, out))
@@ -269,8 +227,7 @@ def get_current_branch_remote(package_dir):
 
 def is_uncommitted(package_dir):
     """Return True if there are uncommitted changes or files in the git working dir."""
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "status", "--porcelain")
+    out, err = run_git_cmd(package_dir, "status", "--porcelain")
     if err:
         raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     if out:
@@ -281,11 +238,11 @@ def is_uncommitted(package_dir):
 
     remote = get_current_branch_remote(package_dir)
 
-    branch = get_branch(package_dir)
+    branch = get_git_branch(package_dir)
     branch_ref = "refs/heads/%s" % branch
     origin_ref_pat = re.compile(r"refs/(urls|remotes)/%s/%s" % (re.escape(remote), re.escape(branch)))
 
-    out, err = run_git_cmd(top_dir, "show-ref")
+    out, err = run_git_cmd(package_dir, "show-ref")
     if err:
         raise VCSError("Exit code %d getting git references for directory %s.  Output:\n%s" % (err, package_dir, out))
     branch_hash = ''
@@ -315,12 +272,11 @@ def is_outdated(package_dir):
 
     """
     remote = get_current_branch_remote(package_dir)
-    branch = get_branch(package_dir)
+    branch = get_git_branch(package_dir)
     branch_ref = "refs/heads/%s" % branch
     branch_hash = ''
 
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "show-ref")
+    out, err = run_git_cmd(package_dir, "show-ref")
     if err:
         raise VCSError("Exit code %d getting git references for directory %s.  Output:\n%s" % (err, package_dir, out))
     for line in out.splitlines():
@@ -333,7 +289,7 @@ def is_outdated(package_dir):
     if not branch_hash:
         raise VCSError("Unable to determine local branch's hash.")
 
-    command = git_cmd(top_dir, "ls-remote", "--heads", remote)
+    command = git_cmd(package_dir, "ls-remote", "--heads", remote)
     out, err = utils.sbacktick(command)
     if err:
         raise VCSError("Exit code %d getting remote git status for directory %s. Output:\n%s" % (err, package_dir, out))
@@ -380,14 +336,7 @@ def verify_package_dir(package_dir):
     """Check if package_dir points to a valid package dir (i.e. contains
     at least an osg/ dir or an upstream/ dir) and is in a git repo.
     """
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "rev-parse", "--show-toplevel")
-    if err:
-        raise VCSError("Exit code %d getting git top-level directory of %s. Output:\n%s" % (err, package_dir, out))
-    if top_dir != out.strip():
-        raise VCSError("Specified package directory (%s) is not a top-level directory in the git repo (%s)." % \
-                       (package_dir, top_dir))
-    out, err = run_git_cmd(top_dir, "ls-files", "osg", "upstream")
+    out, err = run_git_cmd(package_dir, "ls-files", "osg", "upstream")
     if err:
         raise VCSError("Exit code %d getting git subdirectories of %s. Output:\n%s" % (err, package_dir, out))
     for line in out.split("\n"):
@@ -398,8 +347,7 @@ def verify_package_dir(package_dir):
 
 def verify_git_svn_commit(package_dir):
     """Verify the last commit in the git repo actually came from git-svn."""
-    top_dir = os.path.split(os.path.abspath(package_dir))[0]
-    out, err = run_git_cmd(top_dir, "log", "-n", "1")
+    out, err = run_git_cmd(package_dir, "log", "-n", "1")
     if err:
         raise VCSError("Exit code %d getting git log for directory %s. Output:\n%s" % (err, package_dir, out))
 
@@ -411,7 +359,7 @@ def verify_git_svn_commit(package_dir):
 
 
 def verify_correct_remote(package_dir):
-    """Verify the current branch remote is one of the known remotes."""
+    """Verify the current branch remote is one of the known urls."""
     remote = get_current_branch_remote(package_dir)
     known_remote = get_known_remote(package_dir)[0]
     if remote != known_remote:
@@ -424,104 +372,87 @@ def verify_correct_branch(package_dir, buildopts):
     """
     if utils.is_url(package_dir):
         # a git url -- we can only do some of our checks
-        remote, _, branch = parse_git_url(package_dir)
+        remote, _, git_branch = parse_git_url(package_dir)
         if not remote:
             raise VCSError("URL %s failed to parse as a git URL" % package_dir)
     else:
-        branch = get_branch(package_dir)
+        git_branch = get_git_branch(package_dir)
         remote = get_known_remote(package_dir)[1]
 
         verify_correct_remote(package_dir)
 
-        if remote in [constants.OSG_REMOTE, constants.OSG_AUTH_REMOTE]:
+        if remote in REMOTES["osg"].urls:
             verify_git_svn_commit(package_dir)
 
-    # We only have branching rules for OSG and HCC repos
-    if remote not in constants.KNOWN_GIT_REMOTES:
-        return
-
-    if not is_restricted_branch(branch):
-        # Developer branch -- any target ok
-        return
-    for dver in buildopts['enabled_dvers']:
-        target = buildopts['targetopts_by_dver'][dver]['koji_target']
-        if not target:
+    assert buildopts['enabled_dvers'], "No enabled dvers -- catch this sooner"
+    enabled_dvers = sorted(buildopts['enabled_dvers'])
+    _log.debug("found remote %s", remote)
+    for dver in enabled_dvers:
+        koji_target = buildopts['targetopts_by_dver'][dver]['koji_target']
+        if not koji_target:
             _log.debug(f"No koji target for {dver} -- skipping VCS check")
             continue
-        _do_target_remote_checks(target, remote, branch)
-        if not is_restricted_target(target):
-            # Some custom target -- any branch ok
-            continue
-        if not restricted_branch_matches_target(branch, target):
-            raise VCSError("Forbidden to build from %s branch into %s target" % (branch, target))
-
-
-def _do_target_remote_checks_hcc(remote, branch):
-    if remote not in [constants.HCC_REMOTE, constants.HCC_AUTH_REMOTE]:
-        raise Error("""\
-Error: You must build into the HCC repo from a HCC git checkout.
-You must switch git repos or build targets.""")
-
-    if "master" not in branch:
-        raise Error("""\
-Error: Incorrect branch for koji build
-Only allowed to build into the HCC repo from the
-master branch!  You must switch branches.""")
-
-
-def _do_target_remote_checks_osg(remote):
-    if remote not in [constants.OSG_REMOTE, constants.OSG_AUTH_REMOTE]:
-        raise Error("""\
-Error: You must build into the OSG repo from an OSG git checkout.
-You must switch git repos or build targets.""")
-
-
-def _do_target_remote_checks_chtc(remote, branch):
-    if remote not in [constants.CHTC_REMOTE, constants.CHTC_AUTH_REMOTE]:
-        raise Error("""\
-Error: You must build into the CHTC repo from a CHTC git checkout.
-You must switch git repos or build targets.""")
-
-    if "main" not in branch:
-        raise Error("""\
-Error: Incorrect branch for koji build
-Only allowed to build into the CHTC repo from the
-main branch!  You must switch branches.""")
-
-
-def _do_target_remote_checks(target, remote, branch):
-        if target.startswith("hcc-"):
-            _do_target_remote_checks_hcc(remote, branch)
-        elif target.startswith("osg-"):
-            _do_target_remote_checks_osg(remote)
-        elif target.startswith("chtc-"):
-            _do_target_remote_checks_chtc(remote, branch)
+        for rt in RESTRICTED_TARGETS.values():
+            target_match = rt.koji_target_re.fullmatch(koji_target)
+            if not target_match:
+                continue
+            if not rt.git_branch_re:
+                raise VCSError(f"cannot build into {koji_target} from Git")
+            if remote not in REMOTES_BY_URL:
+                raise VCSError(f"cannot build into {koji_target} from unrecognized remote {remote}")
+            remote_info = REMOTES_BY_URL[remote]
+            if remote_info.name not in rt.remotes:
+                raise VCSError(f"cannot build into {koji_target} from the {remote_info.repo} remote")
+            _log.debug("remote %s has layout %s", remote_info.name, remote_info.layout)
+            if remote_info.layout == RemoteLayout.LEGACY:
+                branch = git_branch
+                branch_re = rt.git_branch_re
+            elif remote_info.layout == RemoteLayout.SUBTREE:
+                branch = get_subtree_branch(package_dir)
+                branch_re = rt.subtree_branch_re
+            else:
+                assert False, "Unknown remote layout %s" % remote_info.layout
+            if not branch_re:
+                _log.debug(f"{branch} is not in a repo with restricted branches")
+                continue
+            branch_match = branch_re.fullmatch(branch)
+            if not branch_match or target_match.groupdict() != branch_match.groupdict():
+                raise VCSError(f"branch/target mismatch: branch {branch} does not match target {koji_target}")
+            break
+        else:
+            _log.debug(f"{koji_target} is not a restricted target")
 
 
 def koji(package_dir, koji_obj, buildopts):
+    # type: (str, kojiinter.KojiInter, dict) -> int
     """koji task with a git build."""
     if utils.is_url(package_dir):
-        remote, package_name, branch = parse_git_url(package_dir)
+        remote, package_path, branch = parse_git_url(package_dir)
         if not remote:
             raise Error("Package '%s' does not parse as a Git URL" % package_dir)
         rev = branch
     else:
         package_dir = os.path.abspath(package_dir)
-        verify_package_dir(package_dir)
-        package_name = os.path.basename(package_dir)
+        if not verify_package_dir(package_dir):
+            raise UsageError("%s isn't a package directory "
+                             "(must have either osg/ or upstream/ dirs or both)" % (package_dir))
         remote = get_fetch_url(package_dir, get_known_remote(package_dir)[0])
-
-        top_dir = os.path.split(os.path.abspath(package_dir))[0]
-        out, err = run_git_cmd(top_dir, "log", "-1", "--pretty=format:%H")
+        remote_info = REMOTES_BY_URL[remote]
+        if remote_info.layout == RemoteLayout.SUBTREE:
+            package_path = os.path.join(*(pathlib.Path(package_dir).parts[-2:]))
+        else:
+            package_path = os.path.basename(package_dir)
+        out, err = run_git_cmd(package_dir, "log", "-1", "--pretty=format:%H")
         if err:
             raise VCSError("Exit code %d getting git hash for directory %s. Output:\n%s" % (err, package_dir, out))
         rev = out.strip()
 
+    package_name = os.path.basename(package_path)
     if not re.match(r"\w+", package_name): # sanity check
         raise Error("Package '%s' gives invalid package name '%s'" % (package_dir, package_name))
     if not buildopts.get('scratch'):
         koji_obj.add_pkg(package_name)
 
-    return koji_obj.build_git(_normalize_remote(remote),
-                              rev,
-                              package_name)
+    return koji_obj.build_git(remote=_normalize_remote(remote),
+                              rev=rev,
+                              path=package_path)

--- a/osgbuild/git.py
+++ b/osgbuild/git.py
@@ -228,7 +228,7 @@ def get_current_branch_remote(package_dir):
 
 def is_uncommitted(package_dir):
     """Return True if there are uncommitted changes or files in the git working dir."""
-    out, err = run_git_cmd(package_dir, "status", "--porcelain")
+    out, err = run_git_cmd(package_dir, "status", "--porcelain", ".")
     if err:
         raise VCSError("Exit code %d getting git status for directory %s. Output:\n%s" % (err, package_dir, out))
     if out:

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -9,6 +9,7 @@ import os
 import re
 import sys
 import tempfile
+import typing as t
 import urllib.error
 import urllib.request
 import configparser
@@ -39,9 +40,9 @@ log_formatter = logging.Formatter(" >> %(message)s")
 log_consolehandler.setFormatter(log_formatter)
 log.addHandler(log_consolehandler)
 
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 # Main function
-#-------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------
 
 
 def koji_main(buildopts, package_dirs):
@@ -74,41 +75,13 @@ def koji_main(buildopts, package_dirs):
 
     for pkg in package_dirs:
         if buildopts['want_vcs']:
-            # verify working dirs
-            # vcs_module is the module for accessing the repo
-            if svn.is_svn(pkg):
-                vcs_module = svn
-            else:
-                if git.is_git_new_enough() and git.is_git(pkg):
-                    vcs_module = git
-            if not vcs_module:
-                raise VCSError("VCS build requested but could not determine VCS (SVN or Git) for %s" % pkg)
-
-            if not utils.is_url(pkg):
-                try:
-                    vcs_module.verify_working_dir(pkg)
-                except VCSError:
-                    log.error("VCS build requested but no usable VCS (SVN or Git) found for %s", pkg)
-                    raise
-
-            try:
-                koji_targets = [
-                    opts["koji_target"]
-                    for opts in buildopts["targetopts_by_dver"].values()
-                    if "koji_target" in opts
-                ]
-                vcs_module.verify_correct_branch(
-                    package_dir=pkg,
-                    koji_targets=koji_targets,
-                )
-            except VCSError as err:
-                if buildopts['scratch']:
-                    log.warning("\nVCS error for %s: %s\n", pkg, err, exc_info=False)
-                    log.debug("Traceback: %s", traceback.format_exc())
-                    if sys.stdin.isatty() and utils.ask_yn("Abort?"):
-                        raise
-                else:
-                    raise
+            scratch = buildopts["scratch"]
+            koji_targets = [
+                opts["koji_target"]
+                for opts in buildopts["targetopts_by_dver"].values()
+                if "koji_target" in opts
+            ]
+            vcs_module = get_and_verify_vcs(pkg, koji_targets, scratch)
 
         else:
             verify_if_pkg_dir(pkg)
@@ -241,6 +214,47 @@ def watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir):
                         log.info("Results and logs downloaded to %s", destdir)
 
 
+def get_and_verify_vcs(pkg: str, koji_targets: t.Sequence[str], scratch: bool):
+    """
+    Verify working dirs and return the VCS module for accessing the repo.
+
+    Args:
+        pkg: the package name to verify
+        koji_targets: the list of Koji targets to verify
+        scratch: whether the build is a scratch build
+            (and therefore branch verification may be ignored)
+
+    Returns:
+        The VCS module (`svn` or `git`) that can be used to do the build from.
+    """
+    if svn.is_svn(pkg):
+        vcs_module = svn
+    elif git.is_git_new_enough() and git.is_git(pkg):
+        vcs_module = git
+    else:
+        raise VCSError("VCS build requested but could not determine VCS (SVN or Git) for %s" % pkg)
+    if not utils.is_url(pkg):
+        try:
+            vcs_module.verify_working_dir(pkg)
+        except VCSError:
+            log.error("VCS build requested but no usable VCS (SVN or Git) found for %s", pkg)
+            raise
+    try:
+        vcs_module.verify_correct_branch(
+            package_dir=pkg,
+            koji_targets=koji_targets,
+        )
+    except VCSError as err:
+        if scratch:
+            log.warning("\nVCS error for %s: %s\n", pkg, err, exc_info=False)
+            log.debug("Traceback: %s", traceback.format_exc())
+            if sys.stdin.isatty() and utils.ask_yn("Abort?"):
+                raise
+        else:
+            raise
+    return vcs_module
+
+
 def verify_if_pkg_dir(pkg):
     if not os.path.isdir(pkg):
         raise UsageError(pkg + " isn't a directory!")
@@ -249,8 +263,6 @@ def verify_if_pkg_dir(pkg):
         raise UsageError(pkg +
                          " isn't a package directory "
                          "(must have either osg/ or upstream/ dirs or both)")
-
-
 
 
 def init(argv):
@@ -661,7 +673,6 @@ def parser_targetopts_callback(option, opt_str, value, parser, *_, **__):
         if not verify_release_in_targetopts_by_dver(targetopts_by_dver[dver]):
             raise OptionValueError('Inconsistent redhat release in parameter %s: %s' % (opt_str, value))
 # end of parser_targetopts_callback()
-
 
 
 def get_task(args):

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -6,6 +6,7 @@ import logging
 import traceback
 from optparse import OptionGroup, OptionParser, OptionValueError
 import os
+from pathlib import Path
 import re
 import sys
 import tempfile
@@ -59,19 +60,17 @@ def koji_main(buildopts, package_dirs):
 
     require_minimum_version()
 
+    if buildopts.get("repo") not in {None, "", "None"}:
+        for dver in buildopts["enabled_dvers"]:
+            targetopts = buildopts["targetopts_by_dver"][dver]
+            hint = hint_for_dver(repo_hint=buildopts["repo"], dver=dver)
+            for key in ["koji_target", "koji_tag"]:
+                targetopts[key] = targetopts.get(key) or hint[key]
+
+    #
+    # Verify package dirs and VCS
+    #
     vcs_module = None
-
-    #
-    # Verify package dirs
-    #
-
-    # First check that the directories share a prefix, so you can't try to build
-    # 23-main/foo and 24-main/foo at the same time.
-    abs_pkg_dirs = [pkg if utils.is_url(pkg) else os.path.abspath(pkg) for pkg in package_dirs]
-    prefixes = {pkg.rpartition("/")[0] for pkg in abs_pkg_dirs}
-    if len(prefixes) != 1:
-        log.error("Multiple prefixes found: %s", prefixes)
-        raise Error("Package directories must share a directory prefix")
 
     for pkg in package_dirs:
         if buildopts['want_vcs']:
@@ -82,7 +81,6 @@ def koji_main(buildopts, package_dirs):
                 if "koji_target" in opts
             ]
             vcs_module = get_and_verify_vcs(pkg, koji_targets, scratch)
-
         else:
             verify_if_pkg_dir(pkg)
 
@@ -98,10 +96,6 @@ def koji_main(buildopts, package_dirs):
         for build_dver in buildopts['enabled_dvers']:
             dver_buildopts = buildopts.copy()  # type: dict
             dver_buildopts.update(buildopts['targetopts_by_dver'][build_dver])
-            if buildopts.get("repo"):
-                dver_buildopts.setdefault('koji_target', target_for_repo_hint(buildopts['repo'], build_dver))
-                dver_buildopts.setdefault('koji_tag', target_for_repo_hint(buildopts['repo'], build_dver))
-
             if not dver_buildopts.get("koji_target"):
                 raise UsageError("No koji target specified for %s on %s; you may need to specify --repo" % (pkg, build_dver))
             if not dver_buildopts.get("koji_tag"):
@@ -153,8 +147,9 @@ def main(argv=None):
             dver_buildopts = buildopts.copy()
             dver_buildopts.update(buildopts['targetopts_by_dver'][build_dver])
             if task == "mock" and kojiinter and buildopts.get("repo"):
-                dver_buildopts.setdefault('koji_target', target_for_repo_hint(buildopts['repo'], build_dver))
-                dver_buildopts.setdefault('koji_tag', target_for_repo_hint(buildopts['repo'], build_dver))
+                hintinfo = hint_for_dver(buildopts['repo'], build_dver)
+                dver_buildopts.setdefault('koji_target', hintinfo['koji_target'])
+                dver_buildopts.setdefault('koji_tag', hintinfo['koji_tag'])
 
             mock_obj = None
             koji_obj = None
@@ -291,16 +286,33 @@ def init(argv):
     elif task == 'koji' and not kojiinter:
         raise Error('Koji plugin not found.\nInstall osg-build-koji to make the koji task available.')
 
-    buildopts = get_buildopts(options, task)
-    if buildopts['mock_config_from_koji'] and not kojiinter:
-        raise Error('Koji plugin not found.\nInstall osg-build-koji to make getting a Mock config from Koji available.')
-
-    set_loglevel(buildopts.get('loglevel', 'INFO'))
-
+    # Get the package dirs -- we'll need to know one right now to find koji.ini
+    # if there is one.
     package_dirs = args[1:]
     if not package_dirs:
         guess = guess_pkg_dir(os.getcwd())
         package_dirs.append(guess)
+
+    # Check that the directories share a prefix, so you can't try to build
+    # 23-main/foo and 24-main/foo at the same time.
+    abs_pkg_dirs = [pkg if utils.is_url(pkg) else os.path.abspath(pkg) for pkg in package_dirs]
+    prefixes = {pkg.rpartition("/")[0] for pkg in abs_pkg_dirs}
+    if len(prefixes) != 1:
+        log.error("Multiple prefixes found: %s", prefixes)
+        raise UsageError(
+            "Package directories must share a directory prefix.\n"
+            "Building into different repos from the same invocation of osg-build\n"
+            "is not currently possible; you must split up the builds into\n"
+            "separate invocations."
+        )
+
+    # There can be only one koji.ini because the prefixes match
+    buildopts = get_buildopts(options, task, local_koji_ini_path=get_local_koji_ini_path(package_dirs[0]))
+
+    if task == 'mock' and buildopts['mock_config_from_koji'] and not kojiinter:
+        raise Error('Koji plugin not found.\nInstall osg-build-koji to make getting a Mock config from Koji available.')
+
+    set_loglevel(buildopts.get('loglevel', 'INFO'))
 
     if len(package_dirs) >= BACKGROUND_THRESHOLD:
         buildopts["background"] = True
@@ -568,8 +580,7 @@ rpmbuild     Build using rpmbuild(8) on the local machine
             help="Build package directly from SVN/Git (always true for non-scratch builds)"
         )
         koji_group.add_option(
-            "--repo", action="callback",
-            callback=parser_targetopts_callback,
+            "--repo",
             type="string", dest="repo",
             help="Specify a set of repos to build to; use --repo-list to get a list"
             " of valid values for this option")
@@ -587,15 +598,16 @@ rpmbuild     Build using rpmbuild(8) on the local machine
 # end of parse_cmdline_args()
 
 
-def target_for_repo_hint(repo_hint, dver):
+def hint_for_dver(repo_hint, dver):
     hints = repo_hints(valid_koji_targets())
     if repo_hint in hints:
-        return hints[repo_hint]['target'] % {'dver': dver}
+        return {
+            'koji_target': hints[repo_hint]['target'] % {'dver': dver},
+            'koji_tag': hints[repo_hint]['tag'] % {'dver': dver},
+        }
     else:
         raise UsageError("'%s' is not a valid repo.\nValid repos are: %s" % (repo_hint, ", ".join(sorted(hints.keys()))))
 
-def tag_for_repo_hint(repo_hint, dver):
-    return repo_hints(valid_koji_targets())[repo_hint]['tag'] % {'dver': dver}
 
 def parser_targetopts_callback(option, opt_str, value, parser, *_, **__):
     """Handle options in the 'targetopts_by_dver' set, such as --koji-tag,
@@ -607,7 +619,7 @@ def parser_targetopts_callback(option, opt_str, value, parser, *_, **__):
     targetopts_by_dver['7']['koji_tag'] is the koji tag to use when building
     for EL 7.
 
-    enabled_dvers is the set of dvers to actually build for, which the
+    enabled_dvers is the list of dvers to actually build for, which the
     --el6, --el7 and --redhat-release arguments affect. dvers may also be
     implicitly turned on by other arguments, e.g. specifying
     --koji-tag=el7-foobar will implicitly turn on el7 builds.
@@ -631,30 +643,25 @@ def parser_targetopts_callback(option, opt_str, value, parser, *_, **__):
 
     # We also have enabled_dvers for determining which dvers to build for.
     if not getattr(parser.values, 'enabled_dvers', None):
-        parser.values.enabled_dvers = set()
+        parser.values.enabled_dvers = []
     enabled_dvers = parser.values.enabled_dvers
 
     if value is None:
         value = ''
     if opt_name == 'redhat_release':
-        for dver in DVERS:
-            if opt_str == '--'+dver:
-                enabled_dvers.add(dver)
         if opt_str == '--redhat-release':
-            if 'el' + value in DVERS:
-                enabled_dvers.add('el' + value)
-            else:
-                raise OptionValueError("Invalid redhat release value: %r" % value)
+            dver = "el" + value
+        else:
+            dver = opt_str.lstrip("-")
+        if dver in DVERS:
+            if dver not in enabled_dvers:
+                enabled_dvers.append(dver)
+        else:
+            raise OptionValueError("Invalid distro version %s" % dver)
     elif opt_name == 'koji_tag' and value == 'TARGET': # HACK
         assert kojiinter  # shouldn't get here without kojiinter
         for dver in targetopts_by_dver:
             targetopts_by_dver[dver]['koji_tag'] = 'TARGET'
-    elif opt_str == '--repo':
-        assert kojiinter  # shouldn't get here without kojiinter
-        parser.values.repo = value
-        for dver in DVERS:
-            targetopts_by_dver[dver]['koji_target'] = target_for_repo_hint(value, dver)
-            targetopts_by_dver[dver]['koji_tag'] = tag_for_repo_hint(value, dver)
     else:
         dver = utils.get_dver_from_string(value)
 
@@ -662,7 +669,7 @@ def parser_targetopts_callback(option, opt_str, value, parser, *_, **__):
             raise OptionValueError('Unable to determine redhat release in parameter %r: %r' % (opt_str, value))
 
         if dver not in enabled_dvers:
-            enabled_dvers.add(dver)
+            enabled_dvers.append(dver)
             log.debug("Implicitly enabled building for el%s due to %r argument %r" % (dver, opt_str, value))
 
         if opt_name == 'ktt':
@@ -701,7 +708,7 @@ def get_task(args):
 # end of get_task()
 
 
-def get_buildopts(options, task):
+def get_buildopts(options, task, local_koji_ini_path):
     """Return a dict of the build options to use, based on the
     command-line arguments.
 
@@ -741,19 +748,22 @@ def get_buildopts(options, task):
         for dver in DVERS:
             buildopts['targetopts_by_dver'][dver] = DEFAULT_BUILDOPTS_BY_DVER[dver].copy()
 
-    # Which distro versions are we building for? If not specified on the
-    # command line, either build for all (koji) or the dver of the local machine
-    # (others)
-    enabled_dvers = getattr(options, 'enabled_dvers', None)
-    if not enabled_dvers:
-        if task == 'koji':
-            if buildopts['repo'] in DEFAULT_DVERS_BY_REPO:
-                buildopts['enabled_dvers'] = set(DEFAULT_DVERS_BY_REPO[buildopts['repo']])
-            else:
-                buildopts['enabled_dvers'] = set(DEFAULT_DVERS)
-        else:
-            machine_dver = utils.get_local_machine_dver() or FALLBACK_DVER
-            buildopts['enabled_dvers'] = {machine_dver}
+    # Read and merge koji.ini. Even if we're not doing the 'koji' task, we
+    # might use the settings from this for the 'mock' task (if we're taking the
+    # mock config from koji).
+    if local_koji_ini_path is not None:
+        ini_buildopts = (read_local_koji_ini(local_koji_ini_path)) or {}
+        for key, value in ini_buildopts.items():
+            if buildopts.get(key, None) is None:
+                buildopts[key] = value
+
+    if not buildopts.get("enabled_dvers", None):
+        buildopts["enabled_dvers"] = get_enabled_dvers(task, buildopts.get("repo", ""))
+
+    # Cleanup: remove targetopts for dvers we are not building for
+    for key in list(buildopts['targetopts_by_dver'].keys()):
+        if key not in buildopts['enabled_dvers']:
+            del buildopts['targetopts_by_dver'][key]
 
     if task == "koji":
         assert kojiinter, "kojiinter necessary for 'koji' task -- this should have been caught"
@@ -770,6 +780,42 @@ def get_buildopts(options, task):
 
     return buildopts
 # end of get_buildopts()
+
+
+def get_local_koji_ini_path(package_dir: str) -> t.Optional[Path]:
+    package_path = Path(guess_pkg_dir(package_dir))
+    local_koji_ini_path = package_path / ".." / LOCAL_KOJI_INI
+    if local_koji_ini_path.is_file():
+        return local_koji_ini_path
+    else:
+        return None
+
+
+def read_local_koji_ini(local_koji_ini_path) -> t.Dict:
+    cp = configparser.ConfigParser()
+    cp.read(local_koji_ini_path)
+    new_buildopts = {}
+    if "koji" not in cp.sections():
+        return {}
+    known_opts = ["repo"]
+    sec = cp["koji"]
+    for opt in known_opts:
+        if opt in sec:
+            new_buildopts[opt] = sec[opt]
+    return new_buildopts
+
+
+def get_enabled_dvers(task: str, repo: str = "") -> t.List[str]:
+    """
+    Get which distro versions we building for, if they have not been specified
+    on the command line.
+
+    This depends on the task -- for the koji task, build for all dvers supported
+    by the target.  For all other tasks, use the dver of the local machine.
+    """
+    if task != "koji":
+        return [utils.get_local_machine_dver() or FALLBACK_DVER]
+    return DEFAULT_DVERS_BY_REPO.get(repo, DEFAULT_DVERS)
 
 
 def print_version_and_exit():

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -92,7 +92,15 @@ def koji_main(buildopts, package_dirs):
                     raise
 
             try:
-                vcs_module.verify_correct_branch(pkg, buildopts)
+                koji_targets = [
+                    opts["koji_target"]
+                    for opts in buildopts["targetopts_by_dver"].values()
+                    if "koji_target" in opts
+                ]
+                vcs_module.verify_correct_branch(
+                    package_dir=pkg,
+                    koji_targets=koji_targets,
+                )
             except VCSError as err:
                 if buildopts['scratch']:
                     log.warning("\nVCS error for %s: %s\n", pkg, err, exc_info=False)
@@ -103,7 +111,7 @@ def koji_main(buildopts, package_dirs):
                     raise
 
         else:
-            is_pkg_dir(pkg)
+            verify_if_pkg_dir(pkg)
 
     #
     # Main loop
@@ -163,7 +171,7 @@ def main(argv=None):
 
     # verify package dirs
     for pkg in package_dirs:
-        is_pkg_dir(pkg)
+        verify_if_pkg_dir(pkg)
 
     # main loop
     for pkg in package_dirs:
@@ -233,7 +241,7 @@ def watch_tasks_get_files(buildopts, task_ids, task_ids_by_results_dir):
                         log.info("Results and logs downloaded to %s", destdir)
 
 
-def is_pkg_dir(pkg):
+def verify_if_pkg_dir(pkg):
     if not os.path.isdir(pkg):
         raise UsageError(pkg + " isn't a directory!")
     if ((not os.path.isdir(os.path.join(pkg, "osg"))) and

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -80,10 +80,11 @@ def is_outdated(package_dir):
         return False
 
 
-def verify_working_dir(pkg):
+def verify_working_dir(pkg) -> None:
     """Verify if a package working directory has uncommitted changes or is
-    outdated and ask the user what to do. Return True if it's ok to continue.
+    outdated and ask the user what to do.
 
+    Raises VCSError if there is an issue and the user chooses not to continue.
     """
     if is_uncommitted(pkg):
         if not utils.ask_yn("""\

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -3,10 +3,9 @@ import logging
 import re
 import os
 
-from .constants import SVN_RESTRICTED_BRANCHES, KOJI_RESTRICTED_TARGETS
 from .error import Error, VCSError, UsageError
+from .target_protection import RESTRICTED_TARGETS
 from . import utils
-
 
 SVN_ROOT = "https://vdt.cs.wisc.edu/svn"
 SVN_REDHAT_PATH = "/native/redhat"
@@ -90,13 +89,13 @@ def verify_working_dir(pkg):
 Package working directory %s has uncommitted changes that will not be included
 in the SVN build.
 Continue (yes/no)?""" % pkg):
-            return False
+            raise VCSError("Package working directory %s has uncommitted changes." % pkg)
     if is_outdated(pkg):
         if not utils.ask_yn("""\
 Package working directory %s is out of date and its contents may not reflect
 what will be built.
 Continue (yes/no)?""" % pkg):
-            return False
+            raise VCSError("Package working directory %s is out of date." % pkg)
     return True
 
 
@@ -131,103 +130,36 @@ def verify_package_info(package_info):
 # name.
 #
 
-def is_restricted_branch(branch):
-    """branch is an SVN branch such as 'trunk' or 'branches/osg-3.1'.
-    Assumes no extra characters on either side (no 'native/redhat/trunk' or
-    'trunk/gums')
-
-    """
-    for pattern in SVN_RESTRICTED_BRANCHES:
-        if re.search(pattern, branch):
-            return True
-    return False
-
-def is_restricted_target(target):
-    """target is a koji target such as 'el5-osg' or 'osg-3.1-el5'.
-    Assumes no extra characters on either side.
-
-    """
-    for pattern in KOJI_RESTRICTED_TARGETS:
-        if re.search(pattern, target):
-            return True
-    return False
-
-def restricted_branch_matches_target(branch, target):
-    """Return True if the pattern that matches `branch` is associated with the
-    same name (e.g. 'devops', 'main', 'upcoming', 'versioned') as the pattern that
-    matches `target`; False otherwise.
-    Special cases:
-    - if the name is 'versioned' (e.g. we're building from 'branches/osg-3.1') then the versions also have to match.
-    - treat 'main' (i.e. 'trunk') as 'versioned' with a version of '3.5'
-    - if the name is 'upcoming' (e.g. building from 'branches/3.6-upcoming') then the versions also have to match.
-      treat a missing version ('branches/upcoming') as '3.5'
-
-    Precondition: is_restricted_branch(branch) and is_restricted_target(target)
-    are True.
-
-    """
-    branch_match = branch_name = target_match = target_name = None
-    for (branch_pattern, branch_name) in SVN_RESTRICTED_BRANCHES.items():
-        branch_match = re.search(branch_pattern, branch)
-        if branch_match:
-            break
-    assert branch_match, \
-            "No SVN_RESTRICTED_BRANCHES pattern matching %s -- is_restricted_branch() should have caught this" % branch
-
-    for (target_pattern, target_name) in KOJI_RESTRICTED_TARGETS.items():
-        target_match = re.search(target_pattern, target)
-        if target_match:
-            break
-    assert target_match, \
-            "No KOJI_RESTRICTED_TARGETS pattern matching %s -- is_restricted_target() should have caught this" % target
-
-    # At this point branch_name should be one of the values (right-hand side) of
-    # SVN_RESTRICTED_BRANCHES, and target_name should be one of the values of
-    # KOJI_RESTRICTED_TARGETS.
-
-    # These might have OSG version numbers ("3.5") in them; make sure they match
-    branch_osgver = branch_match.groupdict().get("osgver", None)
-    target_osgver = target_match.groupdict().get("osgver", None)
-
-    if target_name == "main":
-        target_name = "versioned"
-        target_osgver = "3.6"
-
-    # branch_osgver and target_osgver might be None, e.g. for devops but that's OK
-    return (branch_name == target_name) and (branch_osgver == target_osgver)
 
 def verify_correct_branch(package_dir, buildopts):
-    """Check that the user is not trying to build with bad branch/target
-    combinations. For example, building from osg-3.6 into 3.6-upcoming, or building
-    from osg-3.6 into 23-main.
-
-    """
     package_info = get_package_info(package_dir)
     url = package_info['canon_url']
-    # Check for old, deprecated branches
-    if SVN_REDHAT_PATH + '/trunk/' in url:
-        raise VCSError("trunk has been removed; use branches/osg-3.5 instead")
-    elif SVN_REDHAT_PATH + '/branches/upcoming/' in url:
-        raise VCSError("unversioned upcoming has been removed; use branches/3.5-upcoming instead")
-    branch_match = re.search(SVN_REDHAT_PATH + r'/(branches/[^/]+)/', url)
-    if not branch_match:
-        # Building from a weird path (such as a tag). Be permissive -- koji
-        # itself will catch building from outside SVN so we don't have to
-        return
-    branch = branch_match.group(1)
-    if not is_restricted_branch(branch):
-        # Developer branch -- any target ok
-        return
-    for dver in buildopts['enabled_dvers']:
-        target = buildopts['targetopts_by_dver'][dver]['koji_target']
-        if not target:
+
+    if SVN_REDHAT_PATH + '/branches/' not in url:
+        raise VCSError("must build from a branch in branches/")
+
+    branch = url.rsplit('/')[-2]  # .../branches/osg-3.6/xrootd -> osg-3.6
+    assert buildopts['enabled_dvers'], "No enabled dvers -- catch this sooner"
+    enabled_dvers = sorted(buildopts['enabled_dvers'])
+    for dver in enabled_dvers:
+        koji_target = buildopts['targetopts_by_dver'][dver]['koji_target']
+        if not koji_target:
             _log.debug(f"No koji target for {dver} -- skipping VCS check")
             continue
-        if not is_restricted_target(target):
-            # Some custom target -- any branch ok
-            continue
-        if not restricted_branch_matches_target(branch, target):
-            raise VCSError("Forbidden to build from %s branch into %s target" % (branch, target))
+        for rt in RESTRICTED_TARGETS.values():
+            target_match = rt.koji_target_re.fullmatch(koji_target)
+            if not target_match:
+                continue
+            if not rt.subtree_branch_re:
+                raise VCSError(f"cannot build into {koji_target} from SVN")
+            branch_match = rt.subtree_branch_re.fullmatch(branch)
+            if not branch_match:
+                raise VCSError(f"branch/target mismatch: {branch} does not match {koji_target}")
+            if target_match.groupdict() != branch_match.groupdict():
+                raise VCSError(f"branch/target mismatch: {branch} does not match {koji_target}")
+            break
+        else:
+            _log.debug(f"{koji_target} is not a restricted target")
 
 
 def get_package_info(package_dir):

--- a/osgbuild/svn.py
+++ b/osgbuild/svn.py
@@ -2,6 +2,7 @@
 import logging
 import re
 import os
+import typing as t
 
 from .error import Error, VCSError, UsageError
 from .target_protection import RESTRICTED_TARGETS
@@ -131,7 +132,10 @@ def verify_package_info(package_info):
 #
 
 
-def verify_correct_branch(package_dir, buildopts):
+def verify_correct_branch(
+        package_dir,
+        koji_targets: t.Sequence[str],
+):
     package_info = get_package_info(package_dir)
     url = package_info['canon_url']
 
@@ -139,13 +143,10 @@ def verify_correct_branch(package_dir, buildopts):
         raise VCSError("must build from a branch in branches/")
 
     branch = url.rsplit('/')[-2]  # .../branches/osg-3.6/xrootd -> osg-3.6
-    assert buildopts['enabled_dvers'], "No enabled dvers -- catch this sooner"
-    enabled_dvers = sorted(buildopts['enabled_dvers'])
-    for dver in enabled_dvers:
-        koji_target = buildopts['targetopts_by_dver'][dver]['koji_target']
-        if not koji_target:
-            _log.debug(f"No koji target for {dver} -- skipping VCS check")
-            continue
+
+    if isinstance(koji_targets, str):
+        koji_targets = [koji_targets]
+    for koji_target in koji_targets:
         for rt in RESTRICTED_TARGETS.values():
             target_match = rt.koji_target_re.fullmatch(koji_target)
             if not target_match:

--- a/osgbuild/target_protection.py
+++ b/osgbuild/target_protection.py
@@ -1,0 +1,269 @@
+import dataclasses
+import enum
+import re
+import typing as t
+
+
+class RestrictedTarget:
+    """
+    RestrictedTarget defines a set of Koji targets that have restrictions on
+    which branches or remotes you can use as sources for (non-scratch) builds.
+
+    The attributes are:
+    - name: used for reference
+    - remotes: a list of Git remote names (see the REMOTES constant) that are
+        allowed to build into this target.  (SVN is handled separately.)
+    - subtree_branch_re: a regexp of subtrees that you are allowed to build
+        into this target from.  A subtree is the parent directory of each
+        package, so "24-main/xrootd" will have the subtree of "24-main".
+        This is used in Git repos with the "subtree" layout and SVN.
+        Not used for Git repos with the "legacy" layout, where each package
+        dir is directly under the top level of the repo.
+    - git_branch_re: a regexp of Git branches that you are allowed to build
+        into this target from.  This is for Git repos with the "legacy"
+        layout, where each package dir is directly under the top level of the
+        repo; note that the pattern should match remote branches
+        (e.g. "origin/master") as well.
+    """
+    remotes: t.List[str]
+    koji_target_re: re.Pattern
+    subtree_branch_re: t.Optional[re.Pattern] = None
+    git_branch_re: re.Pattern = None
+
+    def __init__(
+            self,
+            name: str,
+            remotes: t.Union[str, t.List[str]],
+            koji_target_re: t.Union[str, re.Pattern],
+            subtree_branch_re: t.Union[str, re.Pattern] = None,
+            git_branch_re: t.Union[str, re.Pattern] = None,
+    ):
+        self.name = name
+
+        #
+        # Compile any regexps that are provided as strings.
+        #
+        if isinstance(koji_target_re, str):
+            self.koji_target_re = re.compile(koji_target_re)
+        elif isinstance(koji_target_re, re.Pattern):
+            self.koji_target_re = koji_target_re
+        else:
+            raise TypeError("koji_target_re has the wrong type: %s" % type(koji_target_re))
+
+        if not subtree_branch_re:
+            self.subtree_branch_re = None
+        elif isinstance(subtree_branch_re, str):
+            self.subtree_branch_re = re.compile(subtree_branch_re)
+        elif isinstance(subtree_branch_re, re.Pattern):
+            self.subtree_branch_re = subtree_branch_re
+        else:
+            raise TypeError("subtree_branch_re has the wrong type: %s" % type(subtree_branch_re))
+
+        if isinstance(git_branch_re, str):
+            self.git_branch_re = re.compile(git_branch_re)
+        elif isinstance(git_branch_re, re.Pattern):
+            self.git_branch_re = git_branch_re
+        else:
+            raise TypeError("git_branch_re has the wrong type: %s" % type(git_branch_re))
+
+        # The list of remotes you can build from; if only one is given, make sure we store it as a list.
+        if not remotes:
+            raise ValueError("remotes must contain at least one remote")
+        if isinstance(remotes, str):
+            self.remotes = [remotes]
+        else:
+            self.remotes = remotes
+
+
+
+# The original patterns are here for reference.  Note that the new patterns are not anchored.
+# Use re.fullmatch() or re.match() if you want to anchor them
+# SVN branches implicitly start with 'branches/'
+
+# KOJI_RESTRICTED_TARGETS = {
+#     r'^osg-(el\d+)$'                                : 'main',
+#     r'^osg-(?P<osgver>[0-9.]+)-upcoming-(el\d+)$'   : 'upcoming',
+#     r'^devops-(el\d+)$'                             : 'devops',
+#     r'^osg-(el\d+)-internal$'                       : 'oldinternal',
+#     r'^osg-(?P<osgver>\d+\.\d+)-(el\d+)$'           : 'versioned',
+#     r'^osg-(?P<osgver>[0-9.]+)-main-(el\d+)$'       : 'versioned',
+#     r'^osg-(?P<osgver>[0-9.]+)-internal-(el\d+)$'   : 'internal',
+#     r'^chtc-(el\d+)$'                               : 'chtc',
+# }
+# GIT_RESTRICTED_BRANCHES = {
+#     r'^(\w*/)?(?P<osgver>[0-9.]+)-upcoming$'    : 'upcoming',
+#     r'^(\w*/)?internal$'                        : 'oldinternal',
+#     r'^(\w*/)?devops$'                          : 'devops',
+#     r'^(\w*/)?osg-(?P<osgver>\d+\.\d+)$'        : 'versioned',
+#     r'^(\w*/)?(?P<osgver>[0-9.]+)-main$'        : 'versioned',
+#     r'^(\w*/)?(?P<osgver>[0-9.]+)-internal$'    : 'internal',
+# }
+
+# fmt: off
+
+
+# These are the definitions of restricted targets.
+RESTRICTED_TARGETS = {
+    #
+    # Targets currently used by OSG
+    #
+
+    # Upcoming, e.g. "24-upcoming", which is built with Koji targets with names
+    # like "osg-24-upcoming-el8"
+    "upcoming": RestrictedTarget(
+        name="upcoming",
+        remotes=["osg", "osg2"],
+        koji_target_re      =        r'osg-(?P<osgver>[0-9.]+)-upcoming-(el\d+)',
+        subtree_branch_re   =            r'(?P<osgver>[0-9.]+)-upcoming',
+        git_branch_re       =     r'(\w*/)?(?P<osgver>[0-9.]+)-upcoming',
+    ),
+
+    # Main, e.g. "24-main", which is built with Koji targets with names
+    # like "osg-24-main-el8"
+    "newmain": RestrictedTarget(  # XXX rename to 'main' after I've gotten rid of the osg-elX targets
+        name="newmain",
+        remotes=["osg", "osg2"],
+        koji_target_re      =        r'osg-(?P<osgver>[0-9.]+)-main-(el\d+)',
+        subtree_branch_re   =            r'(?P<osgver>[0-9.]+)-main',
+        git_branch_re       =     r'(\w*/)?(?P<osgver>[0-9.]+)-main',
+    ),
+
+    # Versioned internal, e.g. 24-internal, which is built with Koji targets
+    # with names like "osg-24-internal-el8".
+    "internal": RestrictedTarget(
+        name="internal",
+        remotes=["osg", "osg2"],
+        koji_target_re      =        r'osg-(?P<osgver>[0-9.]+)-internal-(el\d+)',
+        subtree_branch_re   =            r'(?P<osgver>[0-9.]+)-internal',
+        git_branch_re       =     r'(\w*/)?(?P<osgver>[0-9.]+)-internal',
+    ),
+
+    #
+    # Targets used outside of OSG Software
+    #
+    "chtc": RestrictedTarget(
+        name="chtc",
+        remotes=["chtc"],
+        koji_target_re      = r'chtc-(el\d+)',
+        git_branch_re       = r'.*',
+    ),
+    "hcc": RestrictedTarget(
+        name="hcc",
+        remotes=["hcc"],
+        koji_target_re      = r'hcc-(el\d+)',
+        git_branch_re       = r'.*',
+    ),
+
+    #
+    # Past, deprecated OSG Software targets.
+    #
+
+    # The deprecated "osg-internal" branch, which is built into Koji targets with names
+    # like "osg-el7-internal".
+    "oldinternal": RestrictedTarget(
+        name="oldinternal",
+        remotes=["osg", "osg2"],
+        koji_target_re      =  r'osg-(el\d+)-internal',
+        subtree_branch_re   =          r'osg-internal',
+        git_branch_re       =       r'(\w*/)?internal',
+    ),
+    # The deprecated "devops" branch, which is built into Koji targets with names
+    # like "devops-el7".
+    "devops": RestrictedTarget(
+        name="devops",
+        remotes=["osg", "osg2"],
+        koji_target_re      =          r'devops-(el\d+)',
+        subtree_branch_re   =          r'devops',
+        git_branch_re       =   r'(\w*/)?devops',
+    ),
+    # The versioned OSG branches, e.g. osg-3.5, osg-3.6, etc., built into Koji
+    # targets with names like "osg-3.6-el7".
+    "versioned": RestrictedTarget(
+        name="versioned",
+        remotes=["osg", "osg2"],
+        koji_target_re      =          r'osg-(?P<osgver>\d+\.\d+)-(el\d+)',
+        subtree_branch_re   =          r'osg-(?P<osgver>\d+\.\d+)',
+        git_branch_re       =   r'(\w*/)?osg-(?P<osgver>\d+\.\d+)',
+    ),
+}
+
+# fmt: on
+
+class RemoteLayout(enum.Enum):
+    """
+    RemoteLayout is for the two types of Git repo layout:
+    - LEGACY: Each package directory is directly under the top of the tree.
+        Target protection rules match against the Git branch.
+    - SUBTREE: Package directories are one level down from the tree.
+        Target protection rules match against the parent of the package
+        directory.
+    """
+    LEGACY = "legacy"
+    SUBTREE = "subtree"
+
+
+@dataclasses.dataclass
+class GitHubRemoteType:
+    """
+    A remote that defines a GitHub repo.  The attributes are:
+
+    - name: a symbolic name of the remote, referenced in the RESTRICTED_TARGETS
+        constant.
+    - layout: how the Git repo is laid out.
+    - repo: the "organization/repo" string of the GitHub repo.
+    """
+    name: str  # TODO This feels hacky
+    repo: str
+    layout: RemoteLayout
+
+    @property
+    def unauth(self):
+        """
+        The URL that can be used for cloning the repo without authentication.
+        """
+        return f"https://github.com/{self.repo}"
+
+    @property
+    def auth(self):
+        """
+        The URL that requires authentication and can be used for pushing to the repo.
+        """
+        return f"git@github.com:{self.repo}"
+
+    @property
+    def urls(self):
+        return [self.auth, self.unauth]
+
+    @property
+    def remote_map(self) -> t.Dict[str, str]:
+        """
+        Map the authenticated URL to an anonymous checkout URL.
+        """
+        return {self.auth: self.unauth}
+
+
+# These are the definitions of the 'known' remotes. The names are used by the
+# RESTRICTED_TARGETS constant.
+REMOTES = {
+    "osg": GitHubRemoteType(
+        name="osg",
+        repo="opensciencegrid/Software-Redhat.git",
+        layout=RemoteLayout.LEGACY,
+    ),
+    "hcc": GitHubRemoteType(
+        name="hcc",
+        repo="unlhcc/hcc-packaging.git",
+        layout=RemoteLayout.LEGACY,
+    ),
+    "chtc": GitHubRemoteType(
+        name="chtc",
+        repo="CHTC/packaging.git",
+        layout=RemoteLayout.LEGACY,
+    ),
+    "osg2": GitHubRemoteType(
+        name="osg2",
+        repo="osg-htc/software-packaging.git",
+        layout=RemoteLayout.SUBTREE,
+    ),
+}
+

--- a/osgbuild/test/common.py
+++ b/osgbuild/test/common.py
@@ -7,12 +7,17 @@ import tempfile
 from os.path import join as opj
 
 from osgbuild import svn
+
+from typing import List, Optional
+
 from osgbuild.utils import find_file, errprintf, checked_backtick, checked_call, CalledProcessError
 
 OSG_36 = "native/redhat/branches/osg-3.6"
 OSG_36_UPCOMING = "native/redhat/branches/3.6-upcoming"
 OSG_23_MAIN = "native/redhat/branches/23-main"
 OSG_23_UPCOMING = "native/redhat/branches/23-upcoming"
+OSG_24_MAIN = "native/redhat/branches/24-main"
+OSG_24_UPCOMING = "native/redhat/branches/24-upcoming"
 
 
 def regex_in_list(pattern, listing):

--- a/osgbuild/test/test_osgbuild.py
+++ b/osgbuild/test/test_osgbuild.py
@@ -259,6 +259,15 @@ class TestFetch(TestCase):
 class TestMisc(TestCase):
     """Other tests"""
 
+    def test_constants(self):
+        self.assertIn(C.FALLBACK_DVER, C.DVERS)
+        for _d in C.DEFAULT_DVERS:
+            self.assertIn(_d, C.DVERS)
+        for _ds in C.DEFAULT_DVERS_BY_REPO.values():
+            for _d in _ds:
+                self.assertIn(_d, C.DVERS)
+                assert _d in C.DVERS
+
     def test_rpmbuild_defines(self):
         buildopts_el = dict()
         build_el = dict()

--- a/osgbuild/test/test_osgbuild_koji.py
+++ b/osgbuild/test/test_osgbuild_koji.py
@@ -6,9 +6,16 @@ import pwd
 import unittest
 from unittest import TestCase
 
-import osgbuild.constants as C
-from osgbuild import main, svn
-from osgbuild.test.common import OSG_23_MAIN, OSG_36, common_setUp, backtick_osg_build, regex_in_list, checked_osg_build
+from osgbuild import main, svn, target_protection
+from osgbuild.test.common import (
+    OSG_23_MAIN,
+    OSG_24_MAIN,
+    OSG_36,
+    backtick_osg_build,
+    checked_osg_build,
+    common_setUp,
+    regex_in_list,
+)
 from osgbuild.utils import CalledProcessError, errprintf
 
 
@@ -30,14 +37,14 @@ class TestKoji(TestCase):
                 re.search(self.build_target_shell_regex % target, output, re.MULTILINE))
 
     def test_koji_shell_args1(self):
-        output = backtick_osg_build(self.kdr_shell + ["--scratch", self.pkg_dir])
+        output = backtick_osg_build(self.kdr_shell + ["--scratch", self.pkg_dir, "--repo", "23-main"])
         self.assertTrue(self.is_building_for("osg.+el8", output),
                         "not building for el8")
         self.assertTrue(self.is_building_for("osg.+el9", output),
                         "not building for el9")
 
     def test_koji_shell_args2(self):
-        output = backtick_osg_build(self.kdr_shell + ["--el9", "--scratch", self.pkg_dir])
+        output = backtick_osg_build(self.kdr_shell + ["--el9", "--scratch", self.pkg_dir, "--repo", "23-main"])
         self.assertFalse(self.is_building_for("osg.+el8", output),
                          "falsely building for el8")
         self.assertTrue(self.is_building_for("osg.+el9", output),
@@ -60,7 +67,7 @@ class TestKoji(TestCase):
             "Bad error with --koji-tag=TARGET")
 
     def test_koji_lib_args1(self):
-        output = backtick_osg_build(self.kdr_lib + ["--scratch", self.pkg_dir])
+        output = backtick_osg_build(self.kdr_lib + ["--scratch", self.pkg_dir, "--repo", "23-main"])
         out_list = output.split("\n")
         self.assertTrue(
             regex_in_list(r".*kojisession.build\([^,]+?, 'osg.+el[89]', " + re.escape("{'scratch': True}") + r", None\)", out_list))
@@ -69,10 +76,11 @@ class TestKoji(TestCase):
         try:
             _ = backtick_osg_build(self.kdr_lib + ["--repo", "3.6-upcoming", "--dry-run", opj(svn.SVN_ROOT, OSG_23_MAIN, "osg-xrootd")])
         except CalledProcessError as err:
-            out_list = err.output.split("\n")
-            self.assertTrue(
-                regex_in_list(r".*Forbidden to build from .+ branch into .+ target", out_list),
-                "did not detect attempt to build for wrong branch (wrong error message)")
+            self.assertIn(
+                "branch/target mismatch:",
+                err.output,
+                "did not detect attempt to build for wrong branch"
+            )
             return
         self.fail("did not detect attempt to build for wrong branch (no error message)")
 
@@ -80,13 +88,15 @@ class TestKoji(TestCase):
         try:
             # SCM URI format is 'git+https://host/.../repo.git?path#revision'
             gitbranch = re.sub(r"^native/redhat/branches/", "", OSG_36)
-            scm_uri = "git+%s?%s#%s" % (C.OSG_REMOTE, "osg-xrootd", gitbranch)
+            osg_unauth_remote = target_protection.REMOTES["osg"].unauth
+            scm_uri = "git+%s?%s#%s" % (osg_unauth_remote, "osg-xrootd", gitbranch)
             _ = backtick_osg_build(self.kdr_lib + ["--repo", "3.6-upcoming", "--dry-run", scm_uri])
         except CalledProcessError as err:
-            out_list = err.output.split("\n")
-            self.assertTrue(
-                regex_in_list(r".*Forbidden to build from .+ branch into .+ target", out_list),
-                "did not detect attempt to build for wrong branch (wrong error message)")
+            self.assertIn(
+                "branch/target mismatch:",
+                err.output,
+                "did not detect attempt to build for wrong branch"
+            )
             return
         self.fail("did not detect attempt to build for wrong branch (no error message)")
 
@@ -154,8 +164,8 @@ class TestMock(TestCase):
     """Tests for mock"""
 
     def setUp(self):
-        self.pkg_dir = common_setUp(opj(OSG_36, "osg-ce"),
-                                    "{2023-07-21}")
+        self.pkg_dir = common_setUp(opj(OSG_24_MAIN, "osg-ca-certs"),
+                                    "{2025-05-01}")
 
     @staticmethod
     def check_for_mock_group():
@@ -175,7 +185,7 @@ class TestMock(TestCase):
 
     def test_mock_koji_cfg(self):
         if self.check_for_mock_group():
-            checked_osg_build(["mock", self.pkg_dir, "--el9", "--mock-config-from-koji=osg-3.6-el9-build"])
+            checked_osg_build(["mock", self.pkg_dir, "--el9", "--mock-config-from-koji=osg-23-main-el9-build"])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is both [SOFTWARE-6078](https://opensciencegrid.atlassian.net/browse/SOFTWARE-6078) and a partial implementation of [SOFTWARE-6066](https://opensciencegrid.atlassian.net/browse/SOFTWARE-6066), since I had been testing them together.

This adds the support for using the https://github.com/osg-htc/software-packaging.git repo, including protection to make sure you can only build into the right Koji targets from the right directories.  SVN and the https://github.com/opensciencegrid/Software-Redhat.git should continue to work as-is.

The only compat-breaking change I can think of is that you may no longer build into restricted targets from unknown branches -- for example, you used to be able to build into `23-main` from the `matyas` branch.  Now you *must* use the `23-main` branch. (This of course only applies to non-scratch builds.)

SOFTWARE-6066 (making `--repo` optional) is partially implemented:

1. The `koji.ini` files only have one recognized option, `repo` (which is the equivalent of `--repo`). The ticket also says you should be able to specify `tag` (a pattern for `--koji-tag`), `target` (a pattern for `--koji-target`) and `dvers` (a list of distro version to build for).

2. You can't build into multiple targets from one invocation so `osg-build koji 23-main/xrootd 24-main/xrootd` doesn't work.

I've squashed the PR into a handful of commits that explain the structure of the changes, as opposed to the timeline -- consider looking at the individual commits instead of the PR as a whole.


[SOFTWARE-6078]: https://opensciencegrid.atlassian.net/browse/SOFTWARE-6078?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SOFTWARE-6066]: https://opensciencegrid.atlassian.net/browse/SOFTWARE-6066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ