### PR TITLE
OSG 25 support

### DIFF
--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -184,6 +184,22 @@ dvers=el8 el9 el10
 extra_dvers=
 required_keys=OSG-25-developer
 
+[route 25-contrib]
+from=osg-25-contrib-%s-staging
+to=osg-25-contrib-%s
+repotag=osg25
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
+[route 25-empty]
+from=osg-25-empty-%s-staging
+to=osg-25-empty-%s
+repotag=osg25
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
 #
 #
 # Other

--- a/data/promoter.ini
+++ b/data/promoter.ini
@@ -140,6 +140,52 @@ required_keys=OSG-24-developer
 
 #
 #
+# OSG 25
+#
+#
+
+[route 25-main]
+from=osg-25-main-%s-development
+to=osg-25-main-%s-testing
+repotag=osg25
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
+[route 25-main-prerelease]
+from=osg-25-main-%s-testing
+to=osg-25-main-%s-prerelease
+repotag=osg25
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
+[route 25-upcoming]
+from=osg-25-upcoming-%s-development
+to=osg-25-upcoming-%s-testing
+repotag=osg25up
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
+[route 25-upcoming-prerelease]
+from=osg-25-upcoming-%s-testing
+to=osg-25-upcoming-%s-prerelease
+repotag=osg25up
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
+[route 25-internal]
+from=osg-25-internal-%s-development
+to=osg-25-internal-%s-release
+repotag=osg25int
+dvers=el8 el9 el10
+extra_dvers=
+required_keys=OSG-25-developer
+
+#
+#
 # Other
 #
 #
@@ -178,3 +224,5 @@ required_keys=CHTC
 23-prerelease=23-main-prerelease
 24-testing=24-main
 24-prerelease=24-main-prerelease
+25-testing=25-main
+25-prerelease=25-main-prerelease

--- a/data/signing_keys.ini
+++ b/data/signing_keys.ini
@@ -36,6 +36,16 @@ keyid=effc3be6
 dvers=el8 el9 el10
 digest_algo = sha256
 
+[key OSG-25-auto]
+keyid=222c5d49
+dvers=el8 el9 el10
+digest_algo = sha256
+
+[key OSG-25-developer]
+keyid=d4e9b1fc
+dvers=el8 el9 el10
+digest_algo = sha256
+
 [key CHTC]
 keyid=30ad7213
 dvers=el8 el9 el10

--- a/osgbuild/constants.py
+++ b/osgbuild/constants.py
@@ -84,6 +84,9 @@ DEFAULT_DVERS_BY_REPO = {
     '24-main': ['el8', 'el9'],
     '24-upcoming': ['el8', 'el9'],
     '24-internal': ['el8', 'el9'],
+    '25-main': ['el8', 'el9', 'el10'],
+    '25-upcoming': ['el8', 'el9', 'el10'],
+    '25-internal': ['el8', 'el9', 'el10'],
     'devops': ['el7', 'el8', 'el9'],
     'chtc': ['el9'],
 }

--- a/osgbuild/main.py
+++ b/osgbuild/main.py
@@ -369,12 +369,20 @@ def repo_hints(targets):
                 osg_internal_match = re.match(r'osg-(\d+)-internal-el\d+', target)
                 osg_empty_match = re.match(r'osg-([0-9.]+)-el\d+-empty', target)
                 osg_contrib_match = re.match(r'osg-([0-9.]+)-el\d+-contrib', target)
+                osg_empty2_match = re.match(r'osg-([0-9.]+)-empty-el\d+', target)
+                osg_contrib2_match = re.match(r'osg-([0-9.]+)-contrib-el\d+', target)
                 if osg_empty_match:
                     osgver = osg_empty_match.group(1)
                     __repo_hints_cache["%s-empty" % osgver] = {'target': 'osg-%s-%%(dver)s-empty' % osgver, 'tag': 'osg-%(dver)s'}
                 elif osg_contrib_match:
                     osgver = osg_contrib_match.group(1)
                     __repo_hints_cache["%s-contrib" % osgver] = {'target': 'osg-%s-%%(dver)s-contrib' % osgver, 'tag': 'osg-%(dver)s'}
+                elif osg_empty2_match:
+                    osgver = osg_empty2_match.group(1)
+                    __repo_hints_cache["%s-empty" % osgver] = {'target': 'osg-%s-empty-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
+                elif osg_contrib2_match:
+                    osgver = osg_contrib2_match.group(1)
+                    __repo_hints_cache["%s-contrib" % osgver] = {'target': 'osg-%s-contrib-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}
                 elif osg_match:
                     osgver = osg_match.group(1)
                     __repo_hints_cache[osgver] = __repo_hints_cache['osg-%s' % osgver] = {'target': 'osg-%s-%%(dver)s' % osgver, 'tag': 'osg-%(dver)s'}

--- a/osgbuild/test/common.py
+++ b/osgbuild/test/common.py
@@ -18,6 +18,8 @@ OSG_23_MAIN = "native/redhat/branches/23-main"
 OSG_23_UPCOMING = "native/redhat/branches/23-upcoming"
 OSG_24_MAIN = "native/redhat/branches/24-main"
 OSG_24_UPCOMING = "native/redhat/branches/24-upcoming"
+OSG_25_MAIN = "native/redhat/branches/25-main"
+OSG_25_UPCOMING = "native/redhat/branches/25-upcoming"
 
 
 def regex_in_list(pattern, listing):


### PR DESCRIPTION
- Update repo hints to deal with contrib and empty tag renaming (SOFTWARE-6054)
- Changes to constants and data files to add OSG 25 support
- Add keyids for OSG-25-auto and OSG-25-developer
- Add routes for 25-contrib and 25-empty
